### PR TITLE
Remove excess `it`s from the inside of spec names

### DIFF
--- a/spec/shale/attribute_spec.rb
+++ b/spec/shale/attribute_spec.rb
@@ -23,14 +23,14 @@ RSpec.describe Shale::Attribute do
 
   describe '#default' do
     context 'when collection is false' do
-      it 'it returns passed default' do
+      it 'returns passed default' do
         attribute = described_class.new('foo', 'bar', false, :default)
         expect(attribute.default).to eq(:default)
       end
     end
 
     context 'when collection is true' do
-      it 'it returns array default' do
+      it 'returns array default' do
         attribute = described_class.new('foo', 'bar', true, :default)
         expect(attribute.default.call).to eq([])
       end
@@ -39,14 +39,14 @@ RSpec.describe Shale::Attribute do
 
   describe '#collection?' do
     context 'when collection is false' do
-      it 'it returns false' do
+      it 'returns false' do
         attribute = described_class.new('foo', 'bar', false, nil)
         expect(attribute.collection?).to eq(false)
       end
     end
 
     context 'when collection is true' do
-      it 'it returns true' do
+      it 'returns true' do
         attribute = described_class.new('foo', 'bar', true, nil)
         expect(attribute.collection?).to eq(true)
       end

--- a/spec/shale/mapping/xml_spec.rb
+++ b/spec/shale/mapping/xml_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Shale::Mapping::Xml do
     end
 
     context 'when namespace is not set' do
-      it 'it will use default namespace' do
+      it 'will use default namespace' do
         obj = described_class.new
         obj.namespace 'http://default.com', 'default'
 
@@ -151,7 +151,7 @@ RSpec.describe Shale::Mapping::Xml do
     end
 
     context 'when namespace and prefix is nil' do
-      it 'it will set namespace and prefix to nil' do
+      it 'will set namespace and prefix to nil' do
         obj = described_class.new
         obj.namespace 'http://default.com', 'default'
 
@@ -164,7 +164,7 @@ RSpec.describe Shale::Mapping::Xml do
     end
 
     context 'when namespace and prefix is set' do
-      it 'it will set namespace and prefix to provided values' do
+      it 'will set namespace and prefix to provided values' do
         obj = described_class.new
         obj.namespace 'http://default.com', 'default'
 
@@ -250,7 +250,7 @@ RSpec.describe Shale::Mapping::Xml do
     end
 
     context 'when namespace and prefix is set' do
-      it 'it will set namespace and prefix to provided values' do
+      it 'will set namespace and prefix to provided values' do
         obj = described_class.new
 
         obj.map_attribute('foo', to: :foo, namespace: 'http://custom.com', prefix: 'custom')
@@ -262,7 +262,7 @@ RSpec.describe Shale::Mapping::Xml do
     end
 
     context 'when default namespace is set' do
-      it 'it will not use default namespace' do
+      it 'will not use default namespace' do
         obj = described_class.new
         obj.namespace 'http://default.com', 'default'
 


### PR DESCRIPTION
Avoid usage of duplicated `it` in spec descriptions like `it 'it returns array default' { }`