### PR TITLE
Handle XML elements with a period (".") in the name

### DIFF
--- a/lib/shale/utils.rb
+++ b/lib/shale/utils.rb
@@ -30,7 +30,8 @@ module Shale
     #
     # @api private
     def self.classify(str)
-      str = str.to_s.sub(/.*\./, '')
+      # names may include a period, which will need to be stripped out
+      str = str.to_s.sub(/\./, '')
 
       str = str.sub(/^[a-z\d]*/) { |match| upcase_first(match) || match }
 

--- a/lib/shale/utils.rb
+++ b/lib/shale/utils.rb
@@ -52,6 +52,8 @@ module Shale
     #
     # @api private
     def self.snake_case(str)
+      # XML elements allow periods and hyphens
+      str = str.to_s.gsub('.', '_')
       return str.to_s unless /[A-Z-]|::/.match?(str)
       word = str.to_s.gsub('::', '/')
       word = word.gsub(/([A-Z]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) do

--- a/spec/shale/schema/compiler/complex_spec.rb
+++ b/spec/shale/schema/compiler/complex_spec.rb
@@ -110,6 +110,13 @@ RSpec.describe Shale::Schema::Compiler::Complex do
         expect(complex.file_name).to eq('package_one/package_two/foo_bar')
       end
     end
+
+    context 'a period is present in the root_name and id' do
+      it 'returns the value' do
+        complex = described_class.new('Foo.Bar:http://www.example.com', 'Foo.Bar', 'PackageOne::PackageTwo')
+        expect(complex.file_name).to eq('package_one/package_two/foo_bar')
+      end
+    end
   end
 
   describe '#relative_path' do

--- a/spec/shale/schema/compiler/property_spec.rb
+++ b/spec/shale/schema/compiler/property_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe Shale::Schema::Compiler::Property do
       property = described_class.new('fooBar', type, false, nil)
       expect(property.attribute_name).to eq('foo_bar')
     end
+
+    # in the wild XML elements have had periods in the element name
+    #
+    # for example
+    #    <xs:element name="Invoice.Item">
+    #      <xs:element name="Value" type="String"/>
+    #    </xs:element>
+    it 'removes periods' do
+      property = described_class.new('Foo.Bar', type, false, nil)
+      expect(property.mapping_name).to eq('Foo.Bar')
+      expect(property.attribute_name).to eq('foo_bar')
+    end
   end
 
   describe '#type' do

--- a/spec/shale/schema/xml_compiler_spec.rb
+++ b/spec/shale/schema/xml_compiler_spec.rb
@@ -45,6 +45,31 @@ RSpec.describe Shale::Schema::XMLCompiler do
       end
     end
 
+    context 'xml schema with a period in the element name' do
+      let(:schema) do
+        <<~SCHEMA
+          <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+          <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:element name="Foo.Bar"/>
+            <xs:element name="Root">
+              <xs:complexType>
+                <xs:element ref="Foo.Bar"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:schema>
+        SCHEMA
+      end
+
+      it 'generates models' do
+        models = described_class.new.as_models([schema])
+
+        expect(models.length).to eq(1)
+        expect(models[0].id).to eq('Root')
+        expect(models[0].properties[0].mapping_name).to eq('Foo.Bar')
+        expect(models[0].properties[0].attribute_name).to eq('foo_bar')
+      end
+    end
+
     context 'with top level complex types' do
       let(:schema) do
         <<~SCHEMA

--- a/spec/shale/schema_spec.rb
+++ b/spec/shale/schema_spec.rb
@@ -177,6 +177,35 @@ RSpec.describe Shale::Schema do
   end
 
   describe '.from_xml' do
+    context 'elements with periods' do
+      let(:schema) do
+        <<~SCHEMA
+          <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+          <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="foo" targetNamespace="foo">
+            <xs:element name="Invoice.Item">
+              <xs:complexType>
+                <xs:element type="string"/>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="Root">
+              <xs:complexType>
+                  <xs:element ref="Invoice.Item"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:schema>
+        SCHEMA
+      end
+
+      it 'generates Shale models' do
+        require 'debug'
+        Shale.xml_adapter = Shale::Adapter::REXML
+        models = described_class.from_xml([schema],
+          namespace_mapping: { 'foo' => 'Namespace' })
+        expect(models.keys).to include('namespace/invoice_item')
+        expect(models.keys).to include('namespace/root')
+      end
+    end
+
     context 'without namespace mapping' do
       let(:schema) do
         <<~DATA

--- a/spec/shale/utils_spec.rb
+++ b/spec/shale/utils_spec.rb
@@ -43,6 +43,15 @@ RSpec.describe Shale::Utils do
       [
         [nil, ''],
         ['', ''],
+
+        # XML allows periods and hyphens in name
+        %w[Foo.Bar foo_bar],
+        %w[foo.Bar foo_bar],
+        %w[foo.bar foo_bar],
+        %w[Foo-Bar foo_bar],
+        %w[foo-Bar foo_bar],
+        %w[foo-bar foo_bar],
+
         %w[foobar foobar],
         %w[fooBar foo_bar],
         %w[foo_bar foo_bar],

--- a/spec/shale/utils_spec.rb
+++ b/spec/shale/utils_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Shale::Utils do
         %w[foo_bar FooBar],
         %w[Foobar Foobar],
         %w[FooBar FooBar],
+        %w[Foo.Bar FooBar],
         ['packageOne/packageTwo/fooBar', 'PackageOne::PackageTwo::FooBar'],
         ['PackageOne/PackageTwo/FooBar', 'PackageOne::PackageTwo::FooBar'],
         ['Package_One/Package_Two/Foo_Bar', 'PackageOne::PackageTwo::FooBar'],


### PR DESCRIPTION
In the wild we have an XSD that uses a "." in an element name, and that was breaking the shale mapped files.