### PR TITLE
Add support for JSON Schema validation keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.0] - [unreleased]
+
+### Added
+- [bkjohnson] Add support for JSON Schema validation keywords (#29)
+
 ## [1.0.0] - 2023-07-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1288,6 +1288,75 @@ end
 Shale::Schema::JSONGenerator.register_json_type(MyEmailType, MyEmailJSONType)
 ```
 
+To add validation keywords to the schema, you can use a custom model and do this:
+
+```ruby
+require 'shale/schema'
+
+class PersonMapper < Shale::Mapper
+  model Person
+
+  attribute :first_name, Shale::Type::String
+  attribute :last_name, Shale::Type::String
+  attribute :address, Shale::Type::String
+  attribute :age, Shale::Type::Integer
+
+  json do
+    properties max_properties: 5
+
+    map "first_name", to: :first_name, schema: { required: true }
+    map "last_name", to: :last_name, schema: { required: true }
+    map "address", to: :age, schema: { max_length: 128 }
+    map "age", to: :age, schema: { minimum: 1, maximum: 150 }
+  end
+end
+
+Shale::Schema.to_json(
+  PersonMapper,
+  pretty: true
+)
+
+# =>
+#
+# {
+#   "$schema": "https://json-schema.org/draft/2020-12/schema",
+#   "description": "My description",
+#   "$ref": "#/$defs/Person",
+#   "$defs": {
+#     "Person": {
+#       "type": "object",
+#       "maxProperties": 5,
+#       "properties": {
+#         "first_name": {
+#           "type": "string"
+#         },
+#         "last_name": {
+#           "type": "string"
+#         },
+#         "age": {
+#           "type": [
+#             "integer",
+#             "null"
+#           ],
+#          "minimum": 1,
+#          "maximum": 150
+#        },
+#         "address": {
+#           "type": [
+#             "string",
+#             "null"
+#           ],
+#           "maxLength": 128
+#         }
+#       },
+#       "required": ["first_name", "last_name"]
+#     }
+#   }
+# }
+```
+
+Validation keywords are supported for all types, only the global `enum` and `const` types are not supported.
+
 ### Compiling JSON Schema into Shale model
 
 :warning: Only **[Draft 2020-12](https://json-schema.org/draft/2020-12/schema)** JSON Schema is supported

--- a/lib/shale/mapping/descriptor/dict.rb
+++ b/lib/shale/mapping/descriptor/dict.rb
@@ -64,6 +64,7 @@ module Shale
         # @param [Hash, nil] methods
         # @param [String, nil] group
         # @param [true, false] render_nil
+        # @param [Hash, nil] schema
         #
         # @api private
         def initialize(name:, attribute:, receiver:, methods:, group:, render_nil:, schema: nil)

--- a/lib/shale/mapping/descriptor/dict.rb
+++ b/lib/shale/mapping/descriptor/dict.rb
@@ -49,6 +49,13 @@ module Shale
         # @api private
         attr_reader :group
 
+        # Return schema hash
+        #
+        # @return [Hash]
+        #
+        # @api private
+        attr_reader :schema
+
         # Initialize instance
         #
         # @param [String] name
@@ -59,12 +66,13 @@ module Shale
         # @param [true, false] render_nil
         #
         # @api private
-        def initialize(name:, attribute:, receiver:, methods:, group:, render_nil:)
+        def initialize(name:, attribute:, receiver:, methods:, group:, render_nil:, schema: nil)
           @name = name
           @attribute = attribute
           @receiver = receiver
           @group = group
           @render_nil = render_nil
+          @schema = schema
 
           if methods
             @method_from = methods[:from]

--- a/lib/shale/mapping/dict.rb
+++ b/lib/shale/mapping/dict.rb
@@ -20,8 +20,8 @@ module Shale
       # @raise [IncorrectMappingArgumentsError] when arguments are incorrect
       #
       # @api private
-      def map(key, to: nil, receiver: nil, using: nil, render_nil: nil)
-        super(key, to: to, receiver: receiver, using: using, render_nil: render_nil)
+      def map(key, to: nil, receiver: nil, using: nil, render_nil: nil, schema: nil)
+        super(key, to: to, receiver: receiver, using: using, render_nil: render_nil, schema: schema)
       end
 
       # Set render_nil default

--- a/lib/shale/mapping/dict.rb
+++ b/lib/shale/mapping/dict.rb
@@ -16,10 +16,11 @@ module Shale
       # @param [Symbol, nil] receiver
       # @param [Hash, nil] using
       # @param [true, false, nil] render_nil
+      # @param [Hash, nil] schema
       #
       # @raise [IncorrectMappingArgumentsError] when arguments are incorrect
       #
-      # @api private
+      # @api public
       def map(key, to: nil, receiver: nil, using: nil, render_nil: nil, schema: nil)
         super(key, to: to, receiver: receiver, using: using, render_nil: render_nil, schema: schema)
       end

--- a/lib/shale/mapping/dict_base.rb
+++ b/lib/shale/mapping/dict_base.rb
@@ -43,6 +43,7 @@ module Shale
       # @param [Hash, nil] using
       # @param [String, nil] group
       # @param [true, false, nil] render_nil
+      # @param [Hash, nil] schema
       #
       # @raise [IncorrectMappingArgumentsError] when arguments are incorrect
       #
@@ -66,6 +67,8 @@ module Shale
       # @param [Integer] min_properties
       # @param [Integer] max_properties
       # @param [Hash] dependent_required
+      #
+      # @api public
       def properties(min_properties: nil, max_properties: nil, dependent_required: nil)
         @root = {
           min_properties: min_properties,

--- a/lib/shale/mapping/dict_base.rb
+++ b/lib/shale/mapping/dict_base.rb
@@ -39,7 +39,7 @@ module Shale
       # @raise [IncorrectMappingArgumentsError] when arguments are incorrect
       #
       # @api private
-      def map(key, to: nil, receiver: nil, using: nil, group: nil, render_nil: nil)
+      def map(key, to: nil, receiver: nil, using: nil, group: nil, render_nil: nil, schema: nil)
         Validator.validate_arguments(key, to, receiver, using)
 
         @keys[key] = Descriptor::Dict.new(
@@ -48,7 +48,8 @@ module Shale
           receiver: receiver,
           methods: using,
           group: group,
-          render_nil: render_nil.nil? ? @render_nil_default : render_nil
+          render_nil: render_nil.nil? ? @render_nil_default : render_nil,
+          schema: schema
         )
       end
 

--- a/lib/shale/mapping/dict_base.rb
+++ b/lib/shale/mapping/dict_base.rb
@@ -16,6 +16,13 @@ module Shale
       # @api private
       attr_reader :keys
 
+      # Return hash for hash with properties for root Object
+      #
+      # @return [Hash]
+      #
+      # @api private
+      attr_reader :root
+
       # Initialize instance
       #
       # @param [true, false] render_nil_default
@@ -23,6 +30,7 @@ module Shale
       # @api private
       def initialize(render_nil_default: false)
         @keys = {}
+        @root = {}
         @finalized = false
         @render_nil_default = render_nil_default
       end
@@ -51,6 +59,19 @@ module Shale
           render_nil: render_nil.nil? ? @render_nil_default : render_nil,
           schema: schema
         )
+      end
+
+      # Allow schema properties to be set on the object
+      #
+      # @param [Integer] min_properties
+      # @param [Integer] max_properties
+      # @param [Hash] dependent_required
+      def properties(min_properties: nil, max_properties: nil, dependent_required: nil)
+        @root = {
+          min_properties: min_properties,
+          max_properties: max_properties,
+          dependent_required: dependent_required,
+        }
       end
 
       # Set the "finalized" instance variable to true

--- a/lib/shale/schema/json_generator.rb
+++ b/lib/shale/schema/json_generator.rb
@@ -107,7 +107,7 @@ module Shale
             properties << json_type
           end
 
-          objects << Object.new(type.model.name, properties)
+          objects << Object.new(type.model.name, properties, type.json_mapping.root)
         end
 
         Schema.new(objects, id: id, title: title, description: description).as_json

--- a/lib/shale/schema/json_generator.rb
+++ b/lib/shale/schema/json_generator.rb
@@ -99,11 +99,11 @@ module Shale
               json_type = json_klass.new(
                 mapping.name,
                 default: default,
-                mapping: mapping
+                schema: mapping.schema
               )
             end
 
-            json_type = Collection.new(json_type, mapping: mapping) if attribute.collection?
+            json_type = Collection.new(json_type, schema: mapping.schema) if attribute.collection?
             properties << json_type
           end
 

--- a/lib/shale/schema/json_generator.rb
+++ b/lib/shale/schema/json_generator.rb
@@ -96,7 +96,11 @@ module Shale
                 default = attribute.type.as_json(value)
               end
 
-              json_type = json_klass.new(mapping.name, default: default)
+              json_type = json_klass.new(
+                mapping.name,
+                default: default,
+                mapping: mapping
+              )
             end
 
             json_type = Collection.new(json_type) if attribute.collection?

--- a/lib/shale/schema/json_generator.rb
+++ b/lib/shale/schema/json_generator.rb
@@ -103,7 +103,7 @@ module Shale
               )
             end
 
-            json_type = Collection.new(json_type) if attribute.collection?
+            json_type = Collection.new(json_type, mapping: mapping) if attribute.collection?
             properties << json_type
           end
 

--- a/lib/shale/schema/json_generator/base.rb
+++ b/lib/shale/schema/json_generator/base.rb
@@ -12,14 +12,17 @@ module Shale
         # @api private
         attr_reader :name
 
+        attr_reader :mapping
+
         # Return nullable
         #
         # @api private
         attr_writer :nullable
 
-        def initialize(name, default: nil)
+        def initialize(name, default: nil, mapping: nil)
           @name = name.gsub('::', '_')
           @default = default
+          @mapping = mapping
           @nullable = true
         end
 

--- a/lib/shale/schema/json_generator/base.rb
+++ b/lib/shale/schema/json_generator/base.rb
@@ -12,6 +12,9 @@ module Shale
         # @api private
         attr_reader :name
 
+        # Return schema hash
+        #
+        # @api private
         attr_reader :schema
 
         # Set nullable

--- a/lib/shale/schema/json_generator/base.rb
+++ b/lib/shale/schema/json_generator/base.rb
@@ -14,7 +14,7 @@ module Shale
 
         attr_reader :mapping
 
-        # Return nullable
+        # Set nullable
         #
         # @api private
         attr_writer :nullable
@@ -23,7 +23,7 @@ module Shale
           @name = name.gsub('::', '_')
           @default = default
           @mapping = mapping
-          @nullable = true
+          @nullable = !mapping&.schema&.[](:required)
         end
 
         # Return JSON Schema fragment as Ruby Hash

--- a/lib/shale/schema/json_generator/base.rb
+++ b/lib/shale/schema/json_generator/base.rb
@@ -12,18 +12,18 @@ module Shale
         # @api private
         attr_reader :name
 
-        attr_reader :mapping
+        attr_reader :schema
 
         # Set nullable
         #
         # @api private
         attr_writer :nullable
 
-        def initialize(name, default: nil, mapping: nil)
+        def initialize(name, default: nil, schema: nil)
           @name = name.gsub('::', '_')
           @default = default
-          @mapping = mapping
-          @nullable = !mapping&.schema&.[](:required)
+          @schema = schema || {}
+          @nullable = !schema&.[](:required)
         end
 
         # Return JSON Schema fragment as Ruby Hash

--- a/lib/shale/schema/json_generator/collection.rb
+++ b/lib/shale/schema/json_generator/collection.rb
@@ -12,8 +12,9 @@ module Shale
         # @param [Shale::Schema::JSONGenerator::Base] type
         #
         # @api private
-        def initialize(type)
+        def initialize(type, mapping: nil)
           @type = type
+          @mapping = mapping
         end
 
         # Delegate name to wrapped type object
@@ -31,7 +32,15 @@ module Shale
         #
         # @api private
         def as_json
-          { 'type' => 'array', 'items' => @type.as_type }
+          schema = @mapping&.schema || {}
+
+          { 'type' => 'array',
+            'items' => @type.as_type,
+            'minItems' => schema[:min_items],
+            'maxItems' => schema[:max_items],
+            'uniqueItems' => schema[:unique],
+            'minContains' => schema[:min_contains],
+            'maxContains' => schema[:max_contains] }.compact
         end
       end
     end

--- a/lib/shale/schema/json_generator/collection.rb
+++ b/lib/shale/schema/json_generator/collection.rb
@@ -7,6 +7,8 @@ module Shale
       #
       # @api private
       class Collection
+        attr_reader :schema
+
         # Initialize Collection object
         #
         # @param [Shale::Schema::JSONGenerator::Base] type

--- a/lib/shale/schema/json_generator/collection.rb
+++ b/lib/shale/schema/json_generator/collection.rb
@@ -12,9 +12,9 @@ module Shale
         # @param [Shale::Schema::JSONGenerator::Base] type
         #
         # @api private
-        def initialize(type, mapping: nil)
+        def initialize(type, schema: nil)
           @type = type
-          @mapping = mapping
+          @schema = schema
         end
 
         # Delegate name to wrapped type object
@@ -32,7 +32,7 @@ module Shale
         #
         # @api private
         def as_json
-          schema = @mapping&.schema || {}
+          schema = @schema || {}
 
           { 'type' => 'array',
             'items' => @type.as_type,

--- a/lib/shale/schema/json_generator/collection.rb
+++ b/lib/shale/schema/json_generator/collection.rb
@@ -7,11 +7,15 @@ module Shale
       #
       # @api private
       class Collection
+        # Return schema hash
+        #
+        # @api private
         attr_reader :schema
 
         # Initialize Collection object
         #
         # @param [Shale::Schema::JSONGenerator::Base] type
+        # @param [Hash] schema
         #
         # @api private
         def initialize(type, schema: nil)

--- a/lib/shale/schema/json_generator/float.rb
+++ b/lib/shale/schema/json_generator/float.rb
@@ -15,8 +15,6 @@ module Shale
         #
         # @api private
         def as_type
-          schema = mapping&.schema || {}
-
           { 'type' => 'number',
             'exclusiveMinimum' => schema[:exclusive_minimum],
             'exclusiveMaximum' => schema[:exclusive_maximum],

--- a/lib/shale/schema/json_generator/float.rb
+++ b/lib/shale/schema/json_generator/float.rb
@@ -15,7 +15,14 @@ module Shale
         #
         # @api private
         def as_type
-          { 'type' => 'number' }
+          schema = mapping&.schema || {}
+
+          { 'type' => 'number',
+            'exclusiveMinimum' => schema[:exclusive_minimum],
+            'exclusiveMaximum' => schema[:exclusive_maximum],
+            'minimum' => schema[:minimum],
+            'maximum' => schema[:maximum],
+            'multipleOf' => schema[:multiple_of] }.compact
         end
       end
     end

--- a/lib/shale/schema/json_generator/integer.rb
+++ b/lib/shale/schema/json_generator/integer.rb
@@ -15,7 +15,14 @@ module Shale
         #
         # @api private
         def as_type
-          { 'type' => 'integer' }
+          schema = mapping&.schema || {}
+
+          { 'type' => 'integer',
+            'exclusiveMinimum' => schema[:exclusive_minimum],
+            'exclusiveMaximum' => schema[:exclusive_maximum],
+            'minimum' => schema[:minimum],
+            'maximum' => schema[:maximum],
+            'multipleOf' => schema[:multiple_of] }.compact
         end
       end
     end

--- a/lib/shale/schema/json_generator/integer.rb
+++ b/lib/shale/schema/json_generator/integer.rb
@@ -15,8 +15,6 @@ module Shale
         #
         # @api private
         def as_type
-          schema = mapping&.schema || {}
-
           { 'type' => 'integer',
             'exclusiveMinimum' => schema[:exclusive_minimum],
             'exclusiveMaximum' => schema[:exclusive_maximum],

--- a/lib/shale/schema/json_generator/object.rb
+++ b/lib/shale/schema/json_generator/object.rb
@@ -19,8 +19,9 @@ module Shale
         # ] properties
         #
         # @api private
-        def initialize(name, properties)
+        def initialize(name, properties, root)
           super(name)
+          @root = root
           @properties = properties
         end
 
@@ -38,6 +39,9 @@ module Shale
             'type' => 'object',
             'properties' => @properties.to_h { |el| [el.name, el.as_json] },
             'required' => required_props.empty? ? nil : required_props,
+            'minProperties' => @root[:min_properties],
+            'maxProperties' => @root[:max_properties],
+            'dependentRequired' => @root[:dependent_required],
           }.compact
         end
       end

--- a/lib/shale/schema/json_generator/object.rb
+++ b/lib/shale/schema/json_generator/object.rb
@@ -31,7 +31,7 @@ module Shale
         # @api private
         def as_type
           required_props = @properties.filter_map do |prop|
-            prop.name if !prop.is_a?(Collection) && prop.mapping&.schema&.[](:required)
+            prop.name if !prop.is_a?(Collection) && prop&.schema&.[](:required)
           end
 
           {

--- a/lib/shale/schema/json_generator/object.rb
+++ b/lib/shale/schema/json_generator/object.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'base'
-require_relative 'collection'
 
 module Shale
   module Schema
@@ -31,9 +30,7 @@ module Shale
         #
         # @api private
         def as_type
-          required_props = @properties.filter_map do |prop|
-            prop.name if !prop.is_a?(Collection) && prop&.schema&.[](:required)
-          end
+          required_props = @properties.filter_map { |prop| prop.name if prop&.schema&.[](:required) }
 
           {
             'type' => 'object',

--- a/lib/shale/schema/json_generator/object.rb
+++ b/lib/shale/schema/json_generator/object.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'base'
+require_relative 'collection'
 
 module Shale
   module Schema
@@ -29,10 +30,15 @@ module Shale
         #
         # @api private
         def as_type
+          required_props = @properties.filter_map do |prop|
+            prop.name if !prop.is_a?(Collection) && prop.mapping&.schema&.[](:required)
+          end
+
           {
             'type' => 'object',
             'properties' => @properties.to_h { |el| [el.name, el.as_json] },
-          }
+            'required' => required_props.empty? ? nil : required_props,
+          }.compact
         end
       end
     end

--- a/lib/shale/schema/json_generator/object.rb
+++ b/lib/shale/schema/json_generator/object.rb
@@ -16,6 +16,7 @@ module Shale
         #   Array<Shale::Schema::JSONGenerator::Base,
         #   Shale::Schema::JSONGenerator::Collection>
         # ] properties
+        # @param [Hash] root
         #
         # @api private
         def initialize(name, properties, root)

--- a/lib/shale/schema/json_generator/string.rb
+++ b/lib/shale/schema/json_generator/string.rb
@@ -15,7 +15,13 @@ module Shale
         #
         # @api private
         def as_type
-          { 'type' => 'string' }
+          schema = mapping&.schema || {}
+
+          { 'type' => 'string',
+            'format' => schema[:format],
+            'minLength' => schema[:min_length],
+            'maxLength' => schema[:max_length],
+            'pattern' => schema[:pattern] }.compact
         end
       end
     end

--- a/lib/shale/schema/json_generator/string.rb
+++ b/lib/shale/schema/json_generator/string.rb
@@ -15,8 +15,6 @@ module Shale
         #
         # @api private
         def as_type
-          schema = mapping&.schema || {}
-
           { 'type' => 'string',
             'format' => schema[:format],
             'minLength' => schema[:min_length],

--- a/spec/shale/mapper_spec.rb
+++ b/spec/shale/mapper_spec.rb
@@ -87,6 +87,8 @@ module ShaleMapperTesting
     attribute :foo, Shale::Type::String
 
     json do
+      properties min_properties: 1, max_properties: 4, dependent_required: { 'foo' => ['bar'] }
+
       map 'bar', to: :foo
       group from: :method_from, to: :method_to do
         map 'baz'
@@ -662,6 +664,14 @@ RSpec.describe Shale::Mapper do
       expect(mapping['qux'].method_from).to eq(:method_from)
       expect(mapping['qux'].method_to).to eq(:method_to)
       expect(mapping['qux'].group).to match('group_')
+    end
+
+    it 'allows root properties to be specified' do
+      root = ShaleMapperTesting::JsonMapping.json_mapping.root
+
+      expect(root[:min_properties]).to eq(1)
+      expect(root[:max_properties]).to eq(4)
+      expect(root[:dependent_required]).to eq({ 'foo' => ['bar'] })
     end
   end
 

--- a/spec/shale/mapping/descriptor/dict_spec.rb
+++ b/spec/shale/mapping/descriptor/dict_spec.rb
@@ -33,6 +33,36 @@ RSpec.describe Shale::Mapping::Descriptor::Dict do
     end
   end
 
+  describe 'schema' do
+    context 'when schema is set' do
+      it 'returns schema' do
+        obj = described_class.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: false,
+          schema: :bar
+        )
+        expect(obj.schema).to eq(:bar)
+      end
+    end
+
+    context 'when schema is not set' do
+      it 'returns nil' do
+        obj = described_class.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: false
+        )
+        expect(obj.schema).to eq(nil)
+      end
+    end
+  end
   describe '#attribute' do
     context 'when attribute is set' do
       it 'returns attribute' do

--- a/spec/shale/schema/json_generator/base_spec.rb
+++ b/spec/shale/schema/json_generator/base_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'shale/schema/json_generator/base'
+require 'shale/mapping/descriptor/dict'
 
 module ShaleSchemaJSONGeneratorBaseTesting
   class TypeNullable < Shale::Schema::JSONGenerator::Base
@@ -109,6 +110,23 @@ RSpec.describe Shale::Schema::JSONGenerator::Base do
         it 'returns JSON Schema fragment as Hash' do
           type = ShaleSchemaJSONGeneratorBaseTesting::TypeNotNullable.new('foo', default: 'foo')
           type.nullable = true
+
+          expect(type.as_json).to eq({ 'foo' => 'test-type', 'default' => 'foo' })
+        end
+      end
+
+      context 'when schema mapping has required set to true' do
+        it 'returns JSON Schema fragment as Hash' do
+          mapping = Shale::Mapping::Descriptor::Dict.new(
+            name: 'foo',
+            attribute: nil,
+            receiver: nil,
+            methods: nil,
+            group: nil,
+            render_nil: nil,
+            schema: { required: true }
+          )
+          type = ShaleSchemaJSONGeneratorBaseTesting::TypeNotNullable.new('foo', default: 'foo', mapping: mapping)
 
           expect(type.as_json).to eq({ 'foo' => 'test-type', 'default' => 'foo' })
         end

--- a/spec/shale/schema/json_generator/base_spec.rb
+++ b/spec/shale/schema/json_generator/base_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'shale/schema/json_generator/base'
-require 'shale/mapping/descriptor/dict'
 
 module ShaleSchemaJSONGeneratorBaseTesting
   class TypeNullable < Shale::Schema::JSONGenerator::Base
@@ -115,18 +114,10 @@ RSpec.describe Shale::Schema::JSONGenerator::Base do
         end
       end
 
-      context 'when schema mapping has required set to true' do
+      context 'when schema has required set to true' do
         it 'returns JSON Schema fragment as Hash' do
-          mapping = Shale::Mapping::Descriptor::Dict.new(
-            name: 'foo',
-            attribute: nil,
-            receiver: nil,
-            methods: nil,
-            group: nil,
-            render_nil: nil,
-            schema: { required: true }
-          )
-          type = ShaleSchemaJSONGeneratorBaseTesting::TypeNotNullable.new('foo', default: 'foo', mapping: mapping)
+          schema = { required: true }
+          type = ShaleSchemaJSONGeneratorBaseTesting::TypeNotNullable.new('foo', default: 'foo', schema: schema)
 
           expect(type.as_json).to eq({ 'foo' => 'test-type', 'default' => 'foo' })
         end

--- a/spec/shale/schema/json_generator/collection_spec.rb
+++ b/spec/shale/schema/json_generator/collection_spec.rb
@@ -18,23 +18,15 @@ RSpec.describe Shale::Schema::JSONGenerator::Collection do
       expect(described_class.new(type).as_json).to eq(expected)
     end
 
-    context 'when mapping is passed with a schema' do
+    context 'when schema is passed' do
       it 'can include array keywords from JSON schema' do
-        mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: nil,
-          schema: {
-            min_items: 2,
-            max_items: 25,
-            unique: true,
-            min_contains: 5,
-            max_contains: 10,
-          }
-        )
+        schema = {
+          min_items: 2,
+          max_items: 25,
+          unique: true,
+          min_contains: 5,
+          max_contains: 10,
+        }
         expected = {
           'type' => 'array',
           'items' => { 'type' => 'boolean' },
@@ -45,42 +37,26 @@ RSpec.describe Shale::Schema::JSONGenerator::Collection do
           'maxContains' => 10,
 
         }
-        expect(described_class.new(type, mapping: mapping).as_json).to eq(expected)
+        expect(described_class.new(type, schema: schema).as_json).to eq(expected)
       end
 
       it 'can use a subset of schema keywords' do
-        mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: nil,
-          schema: { min_items: 4 }
-        )
+        schema = { min_items: 4 }
         expected = {
           'type' => 'array',
           'items' => { 'type' => 'boolean' },
           'minItems' => 4,
         }
-        expect(described_class.new(type, mapping: mapping).as_json).to eq(expected)
+        expect(described_class.new(type, schema: schema).as_json).to eq(expected)
       end
 
       it 'will not use keywords for other types' do
-        mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: nil,
-          schema: { multiple_of: 3 }
-        )
+        schema = { multiple_of: 3 }
         expected = {
           'type' => 'array',
           'items' => { 'type' => 'boolean' },
         }
-        expect(described_class.new(type, mapping: mapping).as_json).to eq(expected)
+        expect(described_class.new(type, schema: schema).as_json).to eq(expected)
       end
     end
   end

--- a/spec/shale/schema/json_generator/collection_spec.rb
+++ b/spec/shale/schema/json_generator/collection_spec.rb
@@ -12,10 +12,76 @@ RSpec.describe Shale::Schema::JSONGenerator::Collection do
     end
   end
 
-  describe '#as_type' do
+  describe '#as_json' do
     it 'returns JSON Schema fragment as Hash' do
       expected = { 'type' => 'array', 'items' => { 'type' => 'boolean' } }
       expect(described_class.new(type).as_json).to eq(expected)
+    end
+
+    context 'when mapping is passed with a schema' do
+      it 'can include array keywords from JSON schema' do
+        mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: nil,
+          schema: {
+            min_items: 2,
+            max_items: 25,
+            unique: true,
+            min_contains: 5,
+            max_contains: 10,
+          }
+        )
+        expected = {
+          'type' => 'array',
+          'items' => { 'type' => 'boolean' },
+          'minItems' => 2,
+          'maxItems' => 25,
+          'uniqueItems' => true,
+          'minContains' => 5,
+          'maxContains' => 10,
+
+        }
+        expect(described_class.new(type, mapping: mapping).as_json).to eq(expected)
+      end
+
+      it 'can use a subset of schema keywords' do
+        mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: nil,
+          schema: { min_items: 4 }
+        )
+        expected = {
+          'type' => 'array',
+          'items' => { 'type' => 'boolean' },
+          'minItems' => 4,
+        }
+        expect(described_class.new(type, mapping: mapping).as_json).to eq(expected)
+      end
+
+      it 'will not use keywords for other types' do
+        mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: nil,
+          schema: { multiple_of: 3 }
+        )
+        expected = {
+          'type' => 'array',
+          'items' => { 'type' => 'boolean' },
+        }
+        expect(described_class.new(type, mapping: mapping).as_json).to eq(expected)
+      end
     end
   end
 end

--- a/spec/shale/schema/json_generator/float_spec.rb
+++ b/spec/shale/schema/json_generator/float_spec.rb
@@ -9,23 +9,15 @@ RSpec.describe Shale::Schema::JSONGenerator::Float do
       expect(described_class.new('foo').as_type).to eq(expected)
     end
 
-    context 'when mapping is passed with a schema' do
+    context 'when schema is passed' do
       it 'can include numeric keywords from JSON schema' do
-        mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: nil,
-          schema: {
-            exclusive_minimum: 0,
-            exclusive_maximum: 500,
-            minimum: 0,
-            maximum: 100,
-            multiple_of: 4,
-          }
-        )
+        schema = {
+          exclusive_minimum: 0,
+          exclusive_maximum: 500,
+          minimum: 0,
+          maximum: 100,
+          multiple_of: 4,
+        }
         expected = {
           'type' => 'number',
           'exclusiveMinimum' => 0,
@@ -34,35 +26,19 @@ RSpec.describe Shale::Schema::JSONGenerator::Float do
           'maximum' => 100,
           'multipleOf' => 4,
         }
-        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+        expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
       end
 
       it 'can use a subset of schema keywords' do
-        mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: nil,
-          schema: { minimum: 1 }
-        )
+        schema = { minimum: 1 }
         expected = { 'type' => 'number', 'minimum' => 1 }
-        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+        expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
       end
 
       it 'will not use keywords for other types' do
-        mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: nil,
-          schema: { unique_items: true }
-        )
+        schema = { unique_items: true }
         expected = { 'type' => 'number' }
-        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+        expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
       end
     end
   end

--- a/spec/shale/schema/json_generator/float_spec.rb
+++ b/spec/shale/schema/json_generator/float_spec.rb
@@ -8,5 +8,62 @@ RSpec.describe Shale::Schema::JSONGenerator::Float do
       expected = { 'type' => 'number' }
       expect(described_class.new('foo').as_type).to eq(expected)
     end
+
+    context 'when mapping is passed with a schema' do
+      it 'can include numeric keywords from JSON schema' do
+        mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: nil,
+          schema: {
+            exclusive_minimum: 0,
+            exclusive_maximum: 500,
+            minimum: 0,
+            maximum: 100,
+            multiple_of: 4,
+          }
+        )
+        expected = {
+          'type' => 'number',
+          'exclusiveMinimum' => 0,
+          'exclusiveMaximum' => 500,
+          'minimum' => 0,
+          'maximum' => 100,
+          'multipleOf' => 4,
+        }
+        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+      end
+
+      it 'can use a subset of schema keywords' do
+        mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: nil,
+          schema: { minimum: 1 }
+        )
+        expected = { 'type' => 'number', 'minimum' => 1 }
+        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+      end
+
+      it 'will not use keywords for other types' do
+        mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: nil,
+          schema: { unique_items: true }
+        )
+        expected = { 'type' => 'number' }
+        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+      end
+    end
   end
 end

--- a/spec/shale/schema/json_generator/integer_spec.rb
+++ b/spec/shale/schema/json_generator/integer_spec.rb
@@ -1,12 +1,70 @@
 # frozen_string_literal: true
 
 require 'shale/schema/json_generator/integer'
+require 'shale/mapping/descriptor/dict'
 
 RSpec.describe Shale::Schema::JSONGenerator::Integer do
   describe '#as_type' do
     it 'returns JSON Schema fragment as Hash' do
       expected = { 'type' => 'integer' }
       expect(described_class.new('foo').as_type).to eq(expected)
+    end
+
+    context 'when mapping is passed with a schema' do
+      it 'can include numeric keywords from JSON schema' do
+        mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: nil,
+          schema: {
+            exclusive_minimum: 0,
+            exclusive_maximum: 500,
+            minimum: 0,
+            maximum: 100,
+            multiple_of: 4,
+          }
+        )
+        expected = {
+          'type' => 'integer',
+          'exclusiveMinimum' => 0,
+          'exclusiveMaximum' => 500,
+          'minimum' => 0,
+          'maximum' => 100,
+          'multipleOf' => 4,
+        }
+        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+      end
+
+      it 'can use a subset of schema keywords' do
+        mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: nil,
+          schema: { minimum: 1 }
+        )
+        expected = { 'type' => 'integer', 'minimum' => 1 }
+        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+      end
+
+      it 'will not use keywords for other types' do
+        mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: nil,
+          schema: { unique_items: true }
+        )
+        expected = { 'type' => 'integer' }
+        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+      end
     end
   end
 end

--- a/spec/shale/schema/json_generator/integer_spec.rb
+++ b/spec/shale/schema/json_generator/integer_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'shale/schema/json_generator/integer'
-require 'shale/mapping/descriptor/dict'
 
 RSpec.describe Shale::Schema::JSONGenerator::Integer do
   describe '#as_type' do
@@ -10,23 +9,15 @@ RSpec.describe Shale::Schema::JSONGenerator::Integer do
       expect(described_class.new('foo').as_type).to eq(expected)
     end
 
-    context 'when mapping is passed with a schema' do
+    context 'when schema is passed' do
       it 'can include numeric keywords from JSON schema' do
-        mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: nil,
-          schema: {
-            exclusive_minimum: 0,
-            exclusive_maximum: 500,
-            minimum: 0,
-            maximum: 100,
-            multiple_of: 4,
-          }
-        )
+        schema = {
+          exclusive_minimum: 0,
+          exclusive_maximum: 500,
+          minimum: 0,
+          maximum: 100,
+          multiple_of: 4,
+        }
         expected = {
           'type' => 'integer',
           'exclusiveMinimum' => 0,
@@ -35,35 +26,19 @@ RSpec.describe Shale::Schema::JSONGenerator::Integer do
           'maximum' => 100,
           'multipleOf' => 4,
         }
-        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+        expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
       end
 
       it 'can use a subset of schema keywords' do
-        mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: nil,
-          schema: { minimum: 1 }
-        )
+        schema = { minimum: 1 }
         expected = { 'type' => 'integer', 'minimum' => 1 }
-        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+        expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
       end
 
       it 'will not use keywords for other types' do
-        mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: nil,
-          schema: { unique_items: true }
-        )
+        schema = { unique_items: true }
         expected = { 'type' => 'integer' }
-        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+        expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
       end
     end
   end

--- a/spec/shale/schema/json_generator/object_spec.rb
+++ b/spec/shale/schema/json_generator/object_spec.rb
@@ -2,6 +2,7 @@
 
 require 'shale/schema/json_generator/boolean'
 require 'shale/schema/json_generator/object'
+require 'shale/mapping/descriptor/dict'
 
 RSpec.describe Shale::Schema::JSONGenerator::Object do
   let(:types) do
@@ -18,6 +19,46 @@ RSpec.describe Shale::Schema::JSONGenerator::Object do
       }
 
       expect(described_class.new('foo', types).as_type).to eq(expected)
+    end
+
+    context 'with mappings' do
+      it 'puts properties with `required` on their schema into the "required" array' do
+        non_required_mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: false
+        )
+
+        required_mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'bar',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: false,
+          schema: { required: true }
+        )
+
+        types_with_required =
+          [
+            Shale::Schema::JSONGenerator::Boolean.new('foo', mapping: non_required_mapping),
+            Shale::Schema::JSONGenerator::Boolean.new('bar', mapping: required_mapping),
+          ]
+
+        expected = {
+          'type' => 'object',
+          'properties' => {
+            'foo' => { 'type' => %w[boolean null] },
+            'bar' => { 'type' => 'boolean' },
+          },
+          'required' => ['bar'],
+        }
+
+        expect(described_class.new('foo', types_with_required).as_type).to eq(expected)
+      end
     end
   end
 end

--- a/spec/shale/schema/json_generator/object_spec.rb
+++ b/spec/shale/schema/json_generator/object_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Shale::Schema::JSONGenerator::Object do
         },
       }
 
-      expect(described_class.new('foo', types).as_type).to eq(expected)
+      expect(described_class.new('foo', types, {}).as_type).to eq(expected)
     end
 
     context 'with schema' do
@@ -39,7 +39,29 @@ RSpec.describe Shale::Schema::JSONGenerator::Object do
           'required' => ['bar'],
         }
 
-        expect(described_class.new('foo', types_with_required).as_type).to eq(expected)
+        expect(described_class.new('foo', types_with_required, {}).as_type).to eq(expected)
+      end
+    end
+
+    context 'with root properties' do
+      it 'puts properties on the root object' do
+        expected = {
+          'type' => 'object',
+          'minProperties' => 1,
+          'maxProperties' => 5,
+          'dependentRequired' => { 'foo' => ['bar'] },
+          'properties' => {
+            'bar' => { 'type' => %w[boolean null] },
+          },
+        }
+
+        root = {
+          min_properties: 1,
+          max_properties: 5,
+          dependent_required: { 'foo' => ['bar'] },
+        }
+
+        expect(described_class.new('foo', types, root).as_type).to eq(expected)
       end
     end
   end

--- a/spec/shale/schema/json_generator/object_spec.rb
+++ b/spec/shale/schema/json_generator/object_spec.rb
@@ -2,7 +2,6 @@
 
 require 'shale/schema/json_generator/boolean'
 require 'shale/schema/json_generator/object'
-require 'shale/mapping/descriptor/dict'
 
 RSpec.describe Shale::Schema::JSONGenerator::Object do
   let(:types) do
@@ -21,31 +20,14 @@ RSpec.describe Shale::Schema::JSONGenerator::Object do
       expect(described_class.new('foo', types).as_type).to eq(expected)
     end
 
-    context 'with mappings' do
+    context 'with schema' do
       it 'puts properties with `required` on their schema into the "required" array' do
-        non_required_mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: false
-        )
-
-        required_mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'bar',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: false,
-          schema: { required: true }
-        )
+        required_schema = { required: true }
 
         types_with_required =
           [
-            Shale::Schema::JSONGenerator::Boolean.new('foo', mapping: non_required_mapping),
-            Shale::Schema::JSONGenerator::Boolean.new('bar', mapping: required_mapping),
+            Shale::Schema::JSONGenerator::Boolean.new('foo', schema: nil),
+            Shale::Schema::JSONGenerator::Boolean.new('bar', schema: required_schema),
           ]
 
         expected = {

--- a/spec/shale/schema/json_generator/schema_spec.rb
+++ b/spec/shale/schema/json_generator/schema_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Shale::Schema::JSONGenerator::Schema do
     context 'when types are not empty' do
       it 'returns JSON Schema fragment as Hash' do
         types = [
-          Shale::Schema::JSONGenerator::Object.new('Foo', []),
-          Shale::Schema::JSONGenerator::Object.new('Bar', []),
+          Shale::Schema::JSONGenerator::Object.new('Foo', [], {}),
+          Shale::Schema::JSONGenerator::Object.new('Bar', [], {}),
         ]
 
         schema = described_class.new(types)

--- a/spec/shale/schema/json_generator/string_spec.rb
+++ b/spec/shale/schema/json_generator/string_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'shale/schema/json_generator/string'
-require 'shale/mapping/descriptor/dict'
 
 RSpec.describe Shale::Schema::JSONGenerator::String do
   describe '#as_type' do
@@ -9,22 +8,14 @@ RSpec.describe Shale::Schema::JSONGenerator::String do
       expect(described_class.new('foo').as_type).to eq({ 'type' => 'string' })
     end
 
-    context 'when mapping is passed with a schema' do
+    context 'when schema is passed' do
       it 'can include string keywords from JSON schema' do
-        mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: nil,
-          schema: {
-            format: 'email',
-            min_length: 5,
-            max_length: 10,
-            pattern: 'foo-bar',
-          }
-        )
+        schema = {
+          format: 'email',
+          min_length: 5,
+          max_length: 10,
+          pattern: 'foo-bar',
+        }
         expected = {
           'type' => 'string',
           'format' => 'email',
@@ -32,35 +23,19 @@ RSpec.describe Shale::Schema::JSONGenerator::String do
           'maxLength' => 10,
           'pattern' => 'foo-bar',
         }
-        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+        expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
       end
 
       it 'can use a subset of schema keywords' do
-        mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: nil,
-          schema: { min_length: 1 }
-        )
+        schema = { min_length: 1 }
         expected = { 'type' => 'string', 'minLength' => 1 }
-        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+        expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
       end
 
       it 'will not use keywords for other types' do
-        mapping = Shale::Mapping::Descriptor::Dict.new(
-          name: 'foo',
-          attribute: nil,
-          receiver: nil,
-          methods: nil,
-          group: nil,
-          render_nil: nil,
-          schema: { unique_items: true }
-        )
+        schema = { unique_items: true }
         expected = { 'type' => 'string' }
-        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+        expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
       end
     end
   end

--- a/spec/shale/schema/json_generator/string_spec.rb
+++ b/spec/shale/schema/json_generator/string_spec.rb
@@ -1,11 +1,67 @@
 # frozen_string_literal: true
 
 require 'shale/schema/json_generator/string'
+require 'shale/mapping/descriptor/dict'
 
 RSpec.describe Shale::Schema::JSONGenerator::String do
   describe '#as_type' do
     it 'returns JSON Schema fragment as Hash' do
       expect(described_class.new('foo').as_type).to eq({ 'type' => 'string' })
+    end
+
+    context 'when mapping is passed with a schema' do
+      it 'can include string keywords from JSON schema' do
+        mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: nil,
+          schema: {
+            format: 'email',
+            min_length: 5,
+            max_length: 10,
+            pattern: 'foo-bar',
+          }
+        )
+        expected = {
+          'type' => 'string',
+          'format' => 'email',
+          'minLength' => 5,
+          'maxLength' => 10,
+          'pattern' => 'foo-bar',
+        }
+        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+      end
+
+      it 'can use a subset of schema keywords' do
+        mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: nil,
+          schema: { min_length: 1 }
+        )
+        expected = { 'type' => 'string', 'minLength' => 1 }
+        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+      end
+
+      it 'will not use keywords for other types' do
+        mapping = Shale::Mapping::Descriptor::Dict.new(
+          name: 'foo',
+          attribute: nil,
+          receiver: nil,
+          methods: nil,
+          group: nil,
+          render_nil: nil,
+          schema: { unique_items: true }
+        )
+        expected = { 'type' => 'string' }
+        expect(described_class.new('foo', mapping: mapping).as_type).to eq(expected)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #28 

This PR implements most of the ["validators" vocabulary for the 2020-12 draft of JSON Schema][1]. Specifically it allows the following properties to be used on the following types:

## Numeric (Integer and Float shale types)

- `multiple_of` => `multipleOf`
- `maximum` => `maximum`
- `exclusive_maximum` => `exclusiveMaximum`
- `minimum` => `minimum`
- `exclusive_minimum` => `exclusiveMinimum`

## String

- `max_length` => `maxLength`
- `min_length` => `minLength`
- `pattern` => `pattern`

The `format` keyword from the [Format Annotation vocabulary][2] is also allowed.

## Array (Collection shale type)

- `max_items` => `maxItems`
- `min_items` => `minItems`
- `unique` => `uniqueItems`
- `max_contains` => `maxContains`
- `min_contains` => `minContains`

## Object

- `required` => `required`
- `max_properties` => `maxProperties`
- `min_properties` => `minProperties`
- `dependent_required` => `dependentRequired`

---

This PR doesn't add support for the remaining keywords for "any" type:

- `enum`
- `const`


Lastly, right now these don't receive any sort of validation other than making sure that the wrong keywords don't get added to the wrong types.


[1]: https://json-schema.org/draft/2020-12/json-schema-validation
[2]: https://www.learnjsonschema.com/2020-12/format-annotation/