### PR TITLE
Do not ignore the `default` option for collection attributes

### DIFF
--- a/lib/shale/attribute.rb
+++ b/lib/shale/attribute.rb
@@ -30,7 +30,7 @@ module Shale
     # @param [Symbol] name Name of the attribute
     # @param [Shale::Type::Value] type Type of the attribute
     # @param [Boolean] collection Is this attribute a collection
-    # @param [Proc] default Default value
+    # @param [Proc, nil] default Default value
     #
     # @api private
     def initialize(name, type, collection, default)
@@ -38,10 +38,10 @@ module Shale
       @setter = "#{name}="
       @type = type
       @collection = collection
-      @default = collection ? -> { [] } : default
+      @default = default || (collection && -> { [] }) || nil
     end
 
-    # Return wheter attribute is collection or not
+    # Return whether the attribute is a collection or not
     #
     # @return [Boolean]
     #

--- a/spec/shale/attribute_spec.rb
+++ b/spec/shale/attribute_spec.rb
@@ -30,8 +30,13 @@ RSpec.describe Shale::Attribute do
     end
 
     context 'when collection is true' do
-      it 'returns array default' do
+      it 'returns passed default' do
         attribute = described_class.new('foo', 'bar', true, :default)
+        expect(attribute.default).to eq(:default)
+      end
+
+      it 'returns array default when nil' do
+        attribute = described_class.new('foo', 'bar', true, nil)
         expect(attribute.default.call).to eq([])
       end
     end


### PR DESCRIPTION
I noticed that the `default` attribute option is ignored and replaced with `-> { [] }` for collection attributes.

I find it annoying, especially when someone wants the collection to be `nil` by default. Because the `default` option is disabled it is very hard to achieve.

I modified the behaviour so that collection attributes replace the default proc with `-> { [] }` only when `default` is `nil`.

This preserves the original behaviour of collection attributes having an empty array by default when no `default` option is passed. But the provided non-nil `default` is respected.