### PR TITLE
Fix Mapper.attribute's type param documentation

### DIFF
--- a/lib/shale/mapper.rb
+++ b/lib/shale/mapper.rb
@@ -144,7 +144,7 @@ module Shale
       # Define attribute on class
       #
       # @param [Symbol] name Name of the attribute
-      # @param [Shale::Type::Value] type Type of the attribute
+      # @param [Class<Shale::Type::Value>] type Type of the attribute
       # @param [Boolean] collection Is the attribute a collection
       # @param [Proc] default Default value for the attribute
       #


### PR DESCRIPTION
The `type` parameter is expected to be a class that extends `Shale::Type::Value`, not an instance. This corrects that.

Without this fix, tools that use these type warnings for warnings (in my case RubyMine) complain the type is incorrect when used correctly:

![image](https://github.com/kgiszczak/shale/assets/934844/66d4010f-49d8-429d-bd66-c20d03a54df8)

This change corrects the error:

![image](https://github.com/kgiszczak/shale/assets/934844/facf9fa4-4e33-46a8-a53c-c1696166e2db)

While still giving warnings for passing wrong values:

![image](https://github.com/kgiszczak/shale/assets/934844/fb035534-2a07-4f37-a59a-470904ec79d0)
