### PR TITLE
Attribute type aliases with Shale::Type.register and Shale::Type.lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1215,6 +1215,15 @@ Shale supports these types out of the box:
 - `:string` (`Shale::Type::String`)
 - `:time` (`Shale::Type::Time`)
 
+The symbol type alias and the type class are interchangeable:
+
+```ruby
+class Person < Shale::Mapper
+  attribute :age, Shale::Type::Integer
+  # attribute :age, :integer
+end
+```
+
 ### Writing your own type
 
 To add your own type extend it from `Shale::Type::Value` and implement `.cast` class method.
@@ -1229,13 +1238,29 @@ class MyIntegerType < Shale::Type::Value
 end
 ```
 
-You can register your own type with a symbol alias if you
+Then you can use it in your model:
+
+```ruby
+class Person < Shale::Mapper
+  attribute :age, MyIntegerType
+end
+```
+
+You can also register your own type with a symbol alias if you
 intend to use it often.
 
 ```ruby
 require 'shale/type'
 
 Shale::Type.register(:my_integer, MyIntegerType)
+```
+
+Then you can use it like this:
+
+```ruby
+class Person < Shale::Mapper
+  attribute :age, :my_integer
+end
 ```
 
 ### Adapters

--- a/README.md
+++ b/README.md
@@ -83,17 +83,17 @@ $ gem install shale
 require 'shale'
 
 class Address < Shale::Mapper
-  attribute :city, Shale::Type::String
-  attribute :street, Shale::Type::String
-  attribute :zip, Shale::Type::String
+  attribute :city, :string
+  attribute :street, :string
+  attribute :zip, :string
 end
 
 class Person < Shale::Mapper
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
-  attribute :age, Shale::Type::Integer
-  attribute :married, Shale::Type::Boolean, default: -> { false }
-  attribute :hobbies, Shale::Type::String, collection: true
+  attribute :first_name, :string
+  attribute :last_name, :string
+  attribute :age, :integer
+  attribute :married, :boolean, default: -> { false }
+  attribute :hobbies, :string, collection: true
   attribute :address, Address
 end
 ```
@@ -443,8 +443,8 @@ By default keys are named the same as attributes. To use custom keys use:
 
 ```ruby
 class Person < Shale::Mapper
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
+  attribute :first_name, :string
+  attribute :last_name, :string
 
   json do
     map 'firstName', to: :first_name
@@ -457,8 +457,8 @@ end
 
 ```ruby
 class Person < Shale::Mapper
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
+  attribute :first_name, :string
+  attribute :last_name, :string
 
   yaml do
     map 'firstName', to: :first_name
@@ -471,8 +471,8 @@ end
 
 ```ruby
 class Person < Shale::Mapper
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
+  attribute :first_name, :string
+  attribute :last_name, :string
 
   toml do
     map 'firstName', to: :first_name
@@ -489,8 +489,8 @@ to `:first_name` attribute and the second column to `:last_name`.
 
 ```ruby
 class Person < Shale::Mapper
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
+  attribute :first_name, :string
+  attribute :last_name, :string
 
   csv do
     map 'firstName', to: :first_name
@@ -503,8 +503,8 @@ end
 
 ```ruby
 class Person < Shale::Mapper
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
+  attribute :first_name, :string
+  attribute :last_name, :string
 
   hsh do
     map 'firstName', to: :first_name
@@ -519,9 +519,9 @@ XML is more complicated format than JSON or YAML. To map elements, attributes an
 
 ```ruby
 class Address < Shale::Mapper
-  attribute :street, Shale::Type::String
-  attribute :city, Shale::Type::String
-  attribute :zip, Shale::Type::String
+  attribute :street, :string
+  attribute :city, :string
+  attribute :zip, :string
 
   xml do
     map_content to: :street
@@ -531,10 +531,10 @@ class Address < Shale::Mapper
 end
 
 class Person < Shale::Mapper
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
-  attribute :age, Shale::Type::Integer
-  attribute :hobbies, Shale::Type::String, collection: true
+  attribute :first_name, :string
+  attribute :last_name, :string
+  attribute :age, :integer
+  attribute :hobbies, :string, collection: true
   attribute :address, Address
 
   xml do
@@ -573,7 +573,7 @@ You can use `cdata: true` option on `map_element` and `map_content` to handle CD
 
 ```ruby
 class Address < Shale::Mapper
-  attribute :content, Shale::Type::String
+  attribute :content, :string
 
   xml do
     map_content to: :content, cdata: true
@@ -581,7 +581,7 @@ class Address < Shale::Mapper
 end
 
 class Person < Shale::Mapper
-  attribute :first_name, Shale::Type::String
+  attribute :first_name, :string
   attribute :address, Address
 
   xml do
@@ -607,9 +607,9 @@ To map namespaced elements and attributes use `namespace` and `prefix` propertie
 
 ```ruby
 class Person < Shale::Mapper
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
-  attribute :age, Shale::Type::Integer
+  attribute :first_name, :string
+  attribute :last_name, :string
+  attribute :age, :integer
 
   xml do
     root 'person'
@@ -634,11 +634,11 @@ explicitly declare it on `map_attribute`).
 
 ```ruby
 class Person < Shale::Mapper
-  attribute :first_name, Shale::Type::String
-  attribute :middle_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
-  attribute :age, Shale::Type::Integer
-  attribute :hobby, Shale::Type::String
+  attribute :first_name, :string
+  attribute :middle_name, :string
+  attribute :last_name, :string
+  attribute :age, :integer
+  attribute :hobby, :string
 
   xml do
     root 'person'
@@ -674,9 +674,9 @@ For CSV the default is to render `nil` elements.
 
 ```ruby
 class Person < Shale::Mapper
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
-  attribute :age, Shale::Type::Integer
+  attribute :first_name, :string
+  attribute :last_name, :string
+  attribute :age, :integer
 
   json do
     map 'first_name', to: :first_name, render_nil: true
@@ -724,9 +724,9 @@ class Base < Shale::Mapper
 end
 
 class Person < Base
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
-  attribute :age, Shale::Type::Integer
+  attribute :first_name, :string
+  attribute :last_name, :string
+  attribute :age, :integer
 
   json do
     # override default from Base class
@@ -743,8 +743,8 @@ end
 
 ```ruby
 class Person < Base
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
+  attribute :first_name, :string
+  attribute :last_name, :string
 
   json do
     render_nil false
@@ -763,9 +763,9 @@ you can use methods to do so:
 
 ```ruby
 class Person < Shale::Mapper
-  attribute :hobbies, Shale::Type::String, collection: true
-  attribute :street, Shale::Type::String
-  attribute :city, Shale::Type::String
+  attribute :hobbies, :string, collection: true
+  attribute :street, :string
+  attribute :city, :string
 
   json do
     map 'hobbies', using: { from: :hobbies_from_json, to: :hobbies_to_json }
@@ -854,7 +854,7 @@ You can also pass a `context` object that will be available in extractor/generat
 
 ```ruby
 class Person < Shale::Mapper
-  attribute :password, Shale::Type::String
+  attribute :password, :string
 
   json do
     map 'password', using: { from: :password_from_json, to: :password_to_json }
@@ -884,7 +884,7 @@ If you want to work on multiple elements at a time you can group them using `gro
 
 ```ruby
 class Person < Shale::Mapper
-  attribute :name, Shale::Type::String
+  attribute :name, :string
 
   json do
     group from: :name_from_json, to: :name_to_json do
@@ -935,12 +935,12 @@ To delegate fields to child complex types you can use `receiver: :child` declara
 
 ```ruby
 class Address < Shale::Mapper
-  attribute :city, Shale::Type::String
-  attribute :street, Shale::Type::String
+  attribute :city, :string
+  attribute :street, :string
 end
 
 class Person < Shale::Mapper
-  attribute :name, Shale::Type::String
+  attribute :name, :string
   attribute :address, Address
 
   json do
@@ -1060,8 +1060,8 @@ names and shouldn't be included in the returned collection. It also accepts all 
 
 ```ruby
 class Person
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
+  attribute :first_name, :string
+  attribute :last_name, :string
 end
 
 people = Person.from_csv(<<~DATA, headers: true, col_sep: '|')
@@ -1091,10 +1091,10 @@ with NaN values in JSON:
 
 ```ruby
 class Person
-  attribute :age, Shale::Type::Float
+  attribute :age, :float
 end
 
-person = Person.from_jsom('{"age": NaN}', allow_nan: true)
+person = Person.from_json('{"age": NaN}', allow_nan: true)
 
 # =>
 #
@@ -1115,7 +1115,7 @@ It's possible to override an attribute method to change its output:
 
 ```ruby
 class Person < Shale::Mapper
-  attribute :gender, Shale::Type::String
+  attribute :gender, :string
 
   def gender
     if super == 'm'
@@ -1160,15 +1160,15 @@ end
 class AddressMapper < Shale::Mapper
   model Address
 
-  attribute :street, Shale::Type::String
-  attribute :city, Shale::Type::String
+  attribute :street, :string
+  attribute :city, :string
 end
 
 class PersonMapper < Shale::Mapper
   model Person
 
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
+  attribute :first_name, :string
+  attribute :last_name, :string
   attribute :address, AddressMapper
 end
 
@@ -1208,12 +1208,12 @@ PersonMapper.to_json(person, pretty: true)
 
 Shale supports these types out of the box:
 
-- `Shale::Type::Boolean`
-- `Shale::Type::Date`
-- `Shale::Type::Float`
-- `Shale::Type::Integer`
-- `Shale::Type::String`
-- `Shale::Type::Time`
+- `:boolean` (`Shale::Type::Boolean`)
+- `:date` (`Shale::Type::Date`)
+- `:float` (`Shale::Type::Float`)
+- `:integer` (`Shale::Type::Integer`)
+- `:string` (`Shale::Type::String`)
+- `:time` (`Shale::Type::Time`)
 
 ### Writing your own type
 
@@ -1227,6 +1227,15 @@ class MyIntegerType < Shale::Type::Value
     value.to_i
   end
 end
+```
+
+You can register your own type with a symbol alias if you
+intend to use it often.
+
+```ruby
+require 'shale/type'
+
+Shale::Type.register(:my_integer, MyIntegerType)
 ```
 
 ### Adapters
@@ -1381,10 +1390,10 @@ require 'shale/schema'
 class PersonMapper < Shale::Mapper
   model Person
 
-  attribute :first_name, Shale::Type::String
-  attribute :last_name, Shale::Type::String
-  attribute :address, Shale::Type::String
-  attribute :age, Shale::Type::Integer
+  attribute :first_name, :string
+  attribute :last_name, :string
+  attribute :address, :string
+  attribute :age, :integer
 
   json do
     properties max_properties: 5

--- a/lib/shale.rb
+++ b/lib/shale.rb
@@ -4,6 +4,7 @@ require 'yaml'
 
 require_relative 'shale/mapper'
 require_relative 'shale/adapter/json'
+require_relative 'shale/type'
 require_relative 'shale/type/boolean'
 require_relative 'shale/type/date'
 require_relative 'shale/type/float'

--- a/lib/shale/error.rb
+++ b/lib/shale/error.rb
@@ -105,6 +105,18 @@ module Shale
   class NotAShaleMapperError < ShaleError
   end
 
+  # Error for registering class that is not a valid Type::Value
+  #
+  # @api private
+  class NotATypeValueError < ShaleError
+  end
+
+  # Error for using unknown symbol type
+  #
+  # @api private
+  class UnknownTypeError < ShaleError
+  end
+
   # Raised when receiver attribute is not defined
   #
   # @api private

--- a/lib/shale/mapper.rb
+++ b/lib/shale/mapper.rb
@@ -5,6 +5,7 @@ require_relative 'error'
 require_relative 'utils'
 require_relative 'mapping/dict'
 require_relative 'mapping/xml'
+require_relative 'type'
 require_relative 'type/complex'
 
 module Shale
@@ -12,16 +13,16 @@ module Shale
   #
   # @example
   #   class Address < Shale::Mapper
-  #     attribute :city, Shale::Type::String
-  #     attribute :street, Shale::Type::String
-  #     attribute :state, Shale::Type::Integer
-  #     attribute :zip, Shale::Type::String
+  #     attribute :city, :string
+  #     attribute :street, :string
+  #     attribute :state, :string
+  #     attribute :zip, :string
   #   end
   #
   #   class Person < Shale::Mapper
-  #     attribute :first_name, Shale::Type::String
-  #     attribute :last_name, Shale::Type::String
-  #     attribute :age, Shale::Type::Integer
+  #     attribute :first_name, :string
+  #     attribute :last_name, :string
+  #     attribute :age, :integer
   #     attribute :address, Address
   #   end
   #
@@ -144,18 +145,19 @@ module Shale
       # Define attribute on class
       #
       # @param [Symbol] name Name of the attribute
-      # @param [Class<Shale::Type::Value>] type Type of the attribute
+      # @param [Symbol, Class<Shale::Type::Value>] type Type of the attribute
       # @param [Boolean] collection Is the attribute a collection
       # @param [Proc] default Default value for the attribute
       #
       # @raise [DefaultNotCallableError] when attribute's default is not callable
+      # @raise [UnknownTypeError] when type is a symbol and not found in the registry
       #
       # @example
       #   class Person < Shale::Mapper
-      #     attribute :first_name, Shale::Type::String
-      #     attribute :last_name, Shale::Type::String
-      #     attribute :age, Shale::Type::Integer, default: -> { 1 }
-      #     attribute :hobbies, Shale::Type::String, collection: true
+      #     attribute :first_name, :string
+      #     attribute :last_name, :string
+      #     attribute :age, :integer, default: -> { 1 }
+      #     attribute :hobbies, :string, collection: true
       #   end
       #
       #   person = Person.new
@@ -175,6 +177,10 @@ module Shale
 
         unless default.nil? || default.respond_to?(:call)
           raise DefaultNotCallableError.new(to_s, name)
+        end
+
+        if type.is_a?(Symbol)
+          type = Type.lookup(type)
         end
 
         @attributes[name] = Attribute.new(name, type, collection, default)
@@ -201,9 +207,9 @@ module Shale
       #
       # @example
       #   class Person < Shale::Mapper
-      #     attribute :first_name, Shale::Type::String
-      #     attribute :last_name, Shale::Type::String
-      #     attribute :age, Shale::Type::Integer
+      #     attribute :first_name, :string
+      #     attribute :last_name, :string
+      #     attribute :age, :integer
       #
       #     hsh do
       #       map 'firstName', to: :first_name
@@ -225,9 +231,9 @@ module Shale
       #
       # @example
       #   class Person < Shale::Mapper
-      #     attribute :first_name, Shale::Type::String
-      #     attribute :last_name, Shale::Type::String
-      #     attribute :age, Shale::Type::Integer
+      #     attribute :first_name, :string
+      #     attribute :last_name, :string
+      #     attribute :age, :integer
       #
       #     json do
       #       map 'firstName', to: :first_name
@@ -249,9 +255,9 @@ module Shale
       #
       # @example
       #   class Person < Shale::Mapper
-      #     attribute :first_name, Shale::Type::String
-      #     attribute :last_name, Shale::Type::String
-      #     attribute :age, Shale::Type::Integer
+      #     attribute :first_name, :string
+      #     attribute :last_name, :string
+      #     attribute :age, :integer
       #
       #     yaml do
       #       map 'first_name', to: :first_name
@@ -273,9 +279,9 @@ module Shale
       #
       # @example
       #   class Person < Shale::Mapper
-      #     attribute :first_name, Shale::Type::String
-      #     attribute :last_name, Shale::Type::String
-      #     attribute :age, Shale::Type::Integer
+      #     attribute :first_name, :string
+      #     attribute :last_name, :string
+      #     attribute :age, :integer
       #
       #     toml do
       #       map 'first_name', to: :first_name
@@ -297,9 +303,9 @@ module Shale
       #
       # @example
       #   class Person < Shale::Mapper
-      #     attribute :first_name, Shale::Type::String
-      #     attribute :last_name, Shale::Type::String
-      #     attribute :age, Shale::Type::Integer
+      #     attribute :first_name, :string
+      #     attribute :last_name, :string
+      #     attribute :age, :integer
       #
       #     csv do
       #       map 'first_name', to: :first_name
@@ -321,9 +327,9 @@ module Shale
       #
       # @example
       #   class Person < Shale::Mapper
-      #     attribute :first_name, Shale::Type::String
-      #     attribute :last_name, Shale::Type::String
-      #     attribute :age, Shale::Type::Integer
+      #     attribute :first_name, :string
+      #     attribute :last_name, :string
+      #     attribute :age, :integer
       #
       #     xml do
       #       root 'Person'

--- a/lib/shale/type.rb
+++ b/lib/shale/type.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Shale
+  module Type
+    class << self
+      # Register a symbol alias for a Shale::Type::Value class
+      #
+      # @param [Symbol] type Short type alias
+      # @param [Shale::Type::Value] klass Class to register
+      #
+      # @raise [NotATypeValueError] when klass is not a Shale::Type::Value
+      #
+      # @example
+      #   class UnixTimestamp < Shale::Type::Value
+      #     def self.cast(value)
+      #       Time.at(value.to_i)
+      #     end
+      #   end
+      #
+      #   Shale::Type.register(:unix_timestamp, UnixTimestamp)
+      #
+      # @api public
+      def register(type, klass)
+        @registry ||= {}
+
+        unless klass < Value
+          raise NotATypeValueError, "class '#{klass}' is not a valid Shale::Type::Value"
+        end
+
+        @registry[type] = klass
+      end
+
+      # Lookup a Shale::Type::Value class by type alias
+      #
+      # @param [Symbol] type Type alias
+      #
+      # @raise [UnknownTypeError] when type is not registered
+      #
+      # @return [Shale::Type::Value] Class registered for type
+      #
+      # @example
+      #
+      #  Shale::Type.lookup(:unix_timestamp)
+      #  # => UnixTimestamp
+      #
+      # @api public
+      def lookup(type)
+        klass = @registry[type]
+
+        raise UnknownTypeError, "unknown type '#{type}'" unless klass
+
+        klass
+      end
+    end
+  end
+end

--- a/lib/shale/type/boolean.rb
+++ b/lib/shale/type/boolean.rb
@@ -29,5 +29,7 @@ module Shale
         !FALSE_VALUES.include?(value) unless value.nil?
       end
     end
+
+    register(:boolean, Boolean)
   end
 end

--- a/lib/shale/type/date.rb
+++ b/lib/shale/type/date.rb
@@ -69,5 +69,7 @@ module Shale
         value&.iso8601
       end
     end
+
+    register(:date, Date)
   end
 end

--- a/lib/shale/type/float.rb
+++ b/lib/shale/type/float.rb
@@ -25,5 +25,7 @@ module Shale
         end
       end
     end
+
+    register(:float, Float)
   end
 end

--- a/lib/shale/type/integer.rb
+++ b/lib/shale/type/integer.rb
@@ -17,5 +17,7 @@ module Shale
         value&.to_i
       end
     end
+
+    register(:integer, Integer)
   end
 end

--- a/lib/shale/type/string.rb
+++ b/lib/shale/type/string.rb
@@ -17,5 +17,7 @@ module Shale
         value&.to_s
       end
     end
+
+    register(:string, String)
   end
 end

--- a/lib/shale/type/time.rb
+++ b/lib/shale/type/time.rb
@@ -69,5 +69,7 @@ module Shale
         value&.iso8601
       end
     end
+
+    register(:time, Time)
   end
 end

--- a/spec/shale/error_spec.rb
+++ b/spec/shale/error_spec.rb
@@ -56,6 +56,22 @@ RSpec.describe Shale::NotAShaleMapperError do
   end
 end
 
+RSpec.describe Shale::NotATypeValueError do
+  describe 'inheritance' do
+    it 'inherits from Shale::ShaleError' do
+      expect(Shale::NotATypeValueError < Shale::ShaleError).to eq(true)
+    end
+  end 
+end
+
+RSpec.describe Shale::UnknownTypeError do
+  describe 'inheritance' do
+    it 'inherits from Shale::ShaleError' do
+      expect(Shale::UnknownTypeError < Shale::ShaleError).to eq(true)
+    end
+  end
+end
+
 RSpec.describe Shale::AttributeNotDefinedError do
   describe 'inheritance' do
     it 'inherits from Shale::ShaleError' do

--- a/spec/shale/mapper_spec.rb
+++ b/spec/shale/mapper_spec.rb
@@ -8,14 +8,14 @@ module ShaleMapperTesting
   BAR_DEFAULT_PROC = -> { 'bar' }
 
   class Parent < Shale::Mapper
-    attribute :foo, Shale::Type::String
-    attribute :bar, Shale::Type::String, default: BAR_DEFAULT_PROC
-    attribute :baz, Shale::Type::String, collection: true
-    attribute :foo_int, Shale::Type::Integer
+    attribute :foo, :string
+    attribute :bar, :string, default: BAR_DEFAULT_PROC
+    attribute :baz, :string, collection: true
+    attribute :foo_int, :integer
   end
 
   class Child1 < Parent
-    attribute :child1_foo, Shale::Type::String
+    attribute :child1_foo, :string
 
     # rubocop:disable Lint/EmptyBlock
     hsh do
@@ -39,11 +39,11 @@ module ShaleMapperTesting
   end
 
   class Child2 < Child1
-    attribute :child2_foo, Shale::Type::String
+    attribute :child2_foo, :string
   end
 
   class Child3 < Child2
-    attribute :child3_foo, Shale::Type::String
+    attribute :child3_foo, :string
 
     hsh do
       map 'child3_bar', to: :child3_foo
@@ -72,7 +72,7 @@ module ShaleMapperTesting
   end
 
   class HashMapping < Shale::Mapper
-    attribute :foo, Shale::Type::String
+    attribute :foo, :string
 
     hsh do
       map 'bar', to: :foo
@@ -84,7 +84,7 @@ module ShaleMapperTesting
   end
 
   class JsonMapping < Shale::Mapper
-    attribute :foo, Shale::Type::String
+    attribute :foo, :string
 
     json do
       properties min_properties: 1, max_properties: 4, dependent_required: { 'foo' => ['bar'] }
@@ -98,7 +98,7 @@ module ShaleMapperTesting
   end
 
   class YamlMapping < Shale::Mapper
-    attribute :foo, Shale::Type::String
+    attribute :foo, :string
 
     yaml do
       map 'bar', to: :foo
@@ -110,7 +110,7 @@ module ShaleMapperTesting
   end
 
   class TomlMapping < Shale::Mapper
-    attribute :foo, Shale::Type::String
+    attribute :foo, :string
 
     toml do
       map 'bar', to: :foo
@@ -122,7 +122,7 @@ module ShaleMapperTesting
   end
 
   class CsvMapping < Shale::Mapper
-    attribute :foo, Shale::Type::String
+    attribute :foo, :string
 
     csv do
       map 'bar', to: :foo
@@ -134,10 +134,10 @@ module ShaleMapperTesting
   end
 
   class XmlMapping < Shale::Mapper
-    attribute :foo_element, Shale::Type::String
-    attribute :ns2_element, Shale::Type::String
-    attribute :foo_attribute, Shale::Type::String
-    attribute :foo_content, Shale::Type::String
+    attribute :foo_element, :string
+    attribute :ns2_element, :string
+    attribute :foo_attribute, :string
+    attribute :foo_content, :string
 
     xml do
       root 'foobar'
@@ -167,7 +167,7 @@ module ShaleMapperTesting
 
   # rubocop:disable Lint/EmptyBlock
   class FinalizedParent1 < Shale::Mapper
-    attribute :one, Shale::Type::String
+    attribute :one, :string
 
     hsh do
     end
@@ -207,20 +207,20 @@ module ShaleMapperTesting
     xml do
     end
 
-    attribute :one, Shale::Type::String
+    attribute :one, :string
   end
   # rubocop:enable Lint/EmptyBlock
 
   class FinalizedChild1 < FinalizedParent1
-    attribute :two, Shale::Type::String
+    attribute :two, :string
   end
 
   class FinalizedChild2 < FinalizedParent2
-    attribute :two, Shale::Type::String
+    attribute :two, :string
   end
 
   class AttributesModuleParent < Shale::Mapper
-    attribute :parent, Shale::Type::String
+    attribute :parent, :string
 
     def parent
       "#{super}!"
@@ -232,7 +232,7 @@ module ShaleMapperTesting
   end
 
   class AttributesModuleChild < AttributesModuleParent
-    attribute :child, Shale::Type::String
+    attribute :child, :string
 
     def parent
       "#{super}?"
@@ -505,10 +505,22 @@ RSpec.describe Shale::Mapper do
         expect do
           # rubocop:disable Lint/ConstantDefinitionInBlock
           class FooBarBaz < described_class
-            attribute :foo, Shale::Type::String, default: ''
+            attribute :foo, :string, default: ''
           end
           # rubocop:enable Lint/ConstantDefinitionInBlock
         end.to raise_error(Shale::DefaultNotCallableError)
+      end
+    end
+
+    context 'when type is not registered' do
+      it 'raises an error' do
+        expect do
+          # rubocop:disable Lint/ConstantDefinitionInBlock
+          class FooBarBaz < described_class
+            attribute :foo, :unknown
+          end
+          # rubocop:enable Lint/ConstantDefinitionInBlock
+        end.to raise_error(Shale::UnknownTypeError)
       end
     end
 

--- a/spec/shale/mapper_spec.rb
+++ b/spec/shale/mapper_spec.rb
@@ -8,7 +8,7 @@ module ShaleMapperTesting
   BAR_DEFAULT_PROC = -> { 'bar' }
 
   class Parent < Shale::Mapper
-    attribute :foo, :string
+    attribute :foo, Shale::Type::String
     attribute :bar, :string, default: BAR_DEFAULT_PROC
     attribute :baz, :string, collection: true
     attribute :foo_int, :integer

--- a/spec/shale/schema/json_generator_spec.rb
+++ b/spec/shale/schema/json_generator_spec.rb
@@ -6,7 +6,7 @@ require 'shale/error'
 
 module ShaleSchemaJSONGeneratorTesting
   class BranchOne < Shale::Mapper
-    attribute :one, Shale::Type::String
+    attribute :one, :string
 
     json do
       map 'One', to: :one
@@ -14,7 +14,7 @@ module ShaleSchemaJSONGeneratorTesting
   end
 
   class BranchTwo < Shale::Mapper
-    attribute :two, Shale::Type::String
+    attribute :two, :string
 
     json do
       map 'Two', to: :two
@@ -22,30 +22,30 @@ module ShaleSchemaJSONGeneratorTesting
   end
 
   class Root < Shale::Mapper
-    attribute :boolean, Shale::Type::Boolean
-    attribute :date, Shale::Type::Date
-    attribute :float, Shale::Type::Float
-    attribute :integer, Shale::Type::Integer
-    attribute :string, Shale::Type::String
-    attribute :time, Shale::Type::Time
+    attribute :boolean, :boolean
+    attribute :date, :date
+    attribute :float, :float
+    attribute :integer, :integer
+    attribute :string, :string
+    attribute :time, :time
     attribute :value, Shale::Type::Value
 
-    attribute :boolean_default, Shale::Type::Boolean, default: -> { true }
-    attribute :date_default, Shale::Type::Date, default: -> { Date.new(2021, 1, 1) }
-    attribute :float_default, Shale::Type::Float, default: -> { 1.0 }
-    attribute :integer_default, Shale::Type::Integer, default: -> { 1 }
-    attribute :string_default, Shale::Type::String, default: -> { 'string' }
+    attribute :boolean_default, :boolean, default: -> { true }
+    attribute :date_default, :date, default: -> { Date.new(2021, 1, 1) }
+    attribute :float_default, :float, default: -> { 1.0 }
+    attribute :integer_default, :integer, default: -> { 1 }
+    attribute :string_default, :string, default: -> { 'string' }
     attribute :time_default,
-      Shale::Type::Time,
+      :time,
       default: -> { Time.new(2021, 1, 1, 10, 10, 10, '+01:00') }
     attribute :value_default, Shale::Type::Value, default: -> { 'value' }
 
-    attribute :boolean_collection, Shale::Type::Boolean, collection: true
-    attribute :date_collection, Shale::Type::Date, collection: true
-    attribute :float_collection, Shale::Type::Float, collection: true
-    attribute :integer_collection, Shale::Type::Integer, collection: true
-    attribute :string_collection, Shale::Type::String, collection: true
-    attribute :time_collection, Shale::Type::Time, collection: true
+    attribute :boolean_collection, :boolean, collection: true
+    attribute :date_collection, :date, collection: true
+    attribute :float_collection, :float, collection: true
+    attribute :integer_collection, :integer, collection: true
+    attribute :string_collection, :string, collection: true
+    attribute :time_collection, :time, collection: true
     attribute :value_collection, Shale::Type::Value, collection: true
 
     attribute :branch_one, BranchOne
@@ -74,14 +74,14 @@ module ShaleSchemaJSONGeneratorTesting
 
   class AddressMapper < Shale::Mapper
     model Address
-    attribute :street, Shale::Type::String
-    attribute :city, Shale::Type::String
+    attribute :street, :string
+    attribute :city, :string
   end
 
   class PersonMapper < Shale::Mapper
     model Person
-    attribute :first_name, Shale::Type::String
-    attribute :last_name, Shale::Type::String
+    attribute :first_name, :string
+    attribute :last_name, :string
     attribute :address, AddressMapper
   end
 end

--- a/spec/shale/schema/xml_generator_spec.rb
+++ b/spec/shale/schema/xml_generator_spec.rb
@@ -6,8 +6,8 @@ require 'shale/error'
 
 module ShaleSchemaXMLGeneratorTesting
   class BaseNameTesting < Shale::Mapper
-    attribute :foo, Shale::Type::String
-    attribute :bar, Shale::Type::String
+    attribute :foo, :string
+    attribute :bar, :string
 
     xml do
       map_element 'foo', to: :foo
@@ -16,7 +16,7 @@ module ShaleSchemaXMLGeneratorTesting
   end
 
   class BranchOne < Shale::Mapper
-    attribute :one, Shale::Type::String
+    attribute :one, :string
 
     xml do
       root 'branch_two'
@@ -25,7 +25,7 @@ module ShaleSchemaXMLGeneratorTesting
   end
 
   class BranchTwo < Shale::Mapper
-    attribute :two, Shale::Type::String
+    attribute :two, :string
 
     xml do
       root 'branch_two'
@@ -35,39 +35,39 @@ module ShaleSchemaXMLGeneratorTesting
   end
 
   class Root < Shale::Mapper
-    attribute :boolean, Shale::Type::Boolean
-    attribute :date, Shale::Type::Date
-    attribute :float, Shale::Type::Float
-    attribute :integer, Shale::Type::Integer
-    attribute :string, Shale::Type::String
-    attribute :time, Shale::Type::Time
+    attribute :boolean, :boolean
+    attribute :date, :date
+    attribute :float, :float
+    attribute :integer, :integer
+    attribute :string, :string
+    attribute :time, :time
     attribute :value, Shale::Type::Value
 
-    attribute :boolean_default, Shale::Type::Boolean, default: -> { true }
-    attribute :date_default, Shale::Type::Date, default: -> { Date.new(2021, 1, 1) }
-    attribute :float_default, Shale::Type::Float, default: -> { 1.0 }
-    attribute :integer_default, Shale::Type::Integer, default: -> { 1 }
-    attribute :string_default, Shale::Type::String, default: -> { 'string' }
+    attribute :boolean_default, :boolean, default: -> { true }
+    attribute :date_default, :date, default: -> { Date.new(2021, 1, 1) }
+    attribute :float_default, :float, default: -> { 1.0 }
+    attribute :integer_default, :integer, default: -> { 1 }
+    attribute :string_default, :string, default: -> { 'string' }
     attribute :time_default,
-      Shale::Type::Time,
+      :time,
       default: -> { Time.new(2021, 1, 1, 10, 10, 10, '+01:00') }
     attribute :value_default, Shale::Type::Value, default: -> { 'value' }
 
-    attribute :boolean_collection, Shale::Type::Boolean, collection: true
-    attribute :date_collection, Shale::Type::Date, collection: true
-    attribute :float_collection, Shale::Type::Float, collection: true
-    attribute :integer_collection, Shale::Type::Integer, collection: true
-    attribute :string_collection, Shale::Type::String, collection: true
-    attribute :time_collection, Shale::Type::Time, collection: true
+    attribute :boolean_collection, :boolean, collection: true
+    attribute :date_collection, :date, collection: true
+    attribute :float_collection, :float, collection: true
+    attribute :integer_collection, :integer, collection: true
+    attribute :string_collection, :string, collection: true
+    attribute :time_collection, :time, collection: true
     attribute :value_collection, Shale::Type::Value, collection: true
 
     attribute :branch_one, BranchOne
     attribute :branch_two, BranchTwo
     attribute :circular_dependency, Root
 
-    attribute :attribute_one, Shale::Type::String
-    attribute :attribute_two, Shale::Type::String
-    attribute :content, Shale::Type::String
+    attribute :attribute_one, :string
+    attribute :attribute_two, :string
+    attribute :content, :string
 
     xml do
       root 'root'
@@ -126,8 +126,8 @@ module ShaleSchemaXMLGeneratorTesting
 
   class AddressMapper < Shale::Mapper
     model Address
-    attribute :street, Shale::Type::String
-    attribute :city, Shale::Type::String
+    attribute :street, :string
+    attribute :city, :string
 
     xml do
       root 'Bar'
@@ -139,8 +139,8 @@ module ShaleSchemaXMLGeneratorTesting
 
   class PersonMapper < Shale::Mapper
     model Person
-    attribute :first_name, Shale::Type::String
-    attribute :last_name, Shale::Type::String
+    attribute :first_name, :string
+    attribute :last_name, :string
     attribute :address, AddressMapper
 
     xml do

--- a/spec/shale/type/boolean_spec.rb
+++ b/spec/shale/type/boolean_spec.rb
@@ -32,4 +32,8 @@ RSpec.describe Shale::Type::Boolean do
       end
     end
   end
+
+  it 'is a registered type' do
+    expect(Shale::Type.lookup(:boolean)).to eq(described_class)
+  end
 end

--- a/spec/shale/type/complex_spec/with_cdata_spec.rb
+++ b/spec/shale/type/complex_spec/with_cdata_spec.rb
@@ -7,7 +7,7 @@ require 'tomlib'
 
 module ComplexSpec__CDATA # rubocop:disable Naming/ClassAndModuleCamelCase
   class Child < Shale::Mapper
-    attribute :element1, Shale::Type::String
+    attribute :element1, :string
 
     xml do
       root 'child'
@@ -16,8 +16,8 @@ module ComplexSpec__CDATA # rubocop:disable Naming/ClassAndModuleCamelCase
   end
 
   class Parent < Shale::Mapper
-    attribute :element1, Shale::Type::String
-    attribute :element2, Shale::Type::String, collection: true
+    attribute :element1, :string
+    attribute :element2, :string, collection: true
     attribute :child, Child
 
     xml do

--- a/spec/shale/type/complex_spec/with_custom_mapping_spec.rb
+++ b/spec/shale/type/complex_spec/with_custom_mapping_spec.rb
@@ -7,8 +7,8 @@ require 'tomlib'
 
 module ComplexSpec__CustomMapping # rubocop:disable Naming/ClassAndModuleCamelCase
   class Child < Shale::Mapper
-    attribute :one, Shale::Type::String
-    attribute :two, Shale::Type::String, collection: true
+    attribute :one, :string
+    attribute :two, :string, collection: true
 
     hsh do
       map 'One', to: :one
@@ -32,8 +32,8 @@ module ComplexSpec__CustomMapping # rubocop:disable Naming/ClassAndModuleCamelCa
   end
 
   class Parent < Shale::Mapper
-    attribute :one, Shale::Type::String
-    attribute :two, Shale::Type::String, collection: true
+    attribute :one, :string
+    attribute :two, :string, collection: true
     attribute :child, Child
 
     hsh do
@@ -62,8 +62,8 @@ module ComplexSpec__CustomMapping # rubocop:disable Naming/ClassAndModuleCamelCa
   end
 
   class ParentCsv < Shale::Mapper
-    attribute :one, Shale::Type::String
-    attribute :two, Shale::Type::String
+    attribute :one, :string
+    attribute :two, :string
 
     csv do
       map 'One', to: :one
@@ -72,9 +72,9 @@ module ComplexSpec__CustomMapping # rubocop:disable Naming/ClassAndModuleCamelCa
   end
 
   class ChildXml < Shale::Mapper
-    attribute :content, Shale::Type::String
-    attribute :one, Shale::Type::String
-    attribute :two, Shale::Type::String
+    attribute :content, :string
+    attribute :one, :string
+    attribute :two, :string
 
     xml do
       map_content to: :content
@@ -84,11 +84,11 @@ module ComplexSpec__CustomMapping # rubocop:disable Naming/ClassAndModuleCamelCa
   end
 
   class ParentXml < Shale::Mapper
-    attribute :content, Shale::Type::String
-    attribute :one, Shale::Type::String
-    attribute :one_collection, Shale::Type::String, collection: true
-    attribute :two, Shale::Type::String
-    attribute :two_collection, Shale::Type::String, collection: true
+    attribute :content, :string
+    attribute :one, :string
+    attribute :one_collection, :string, collection: true
+    attribute :two, :string
+    attribute :two_collection, :string, collection: true
     attribute :child, ChildXml
 
     xml do

--- a/spec/shale/type/date_spec.rb
+++ b/spec/shale/type/date_spec.rb
@@ -136,4 +136,8 @@ RSpec.describe Shale::Type::Date do
       end
     end
   end
+
+  it 'is a registered type' do
+    expect(Shale::Type.lookup(:date)).to eq(described_class)
+  end
 end

--- a/spec/shale/type/float_spec.rb
+++ b/spec/shale/type/float_spec.rb
@@ -40,4 +40,8 @@ RSpec.describe Shale::Type::Float do
       end
     end
   end
+
+  it 'is a registered type' do
+    expect(Shale::Type.lookup(:float)).to eq(described_class)
+  end
 end

--- a/spec/shale/type/integer_spec.rb
+++ b/spec/shale/type/integer_spec.rb
@@ -16,4 +16,8 @@ RSpec.describe Shale::Type::Integer do
       end
     end
   end
+
+  it 'is a registered type' do
+    expect(Shale::Type.lookup(:integer)).to eq(described_class)
+  end
 end

--- a/spec/shale/type/string_spec.rb
+++ b/spec/shale/type/string_spec.rb
@@ -16,4 +16,8 @@ RSpec.describe Shale::Type::String do
       end
     end
   end
+
+  it 'is a registered type' do
+    expect(Shale::Type.lookup(:string)).to eq(described_class)
+  end
 end

--- a/spec/shale/type/time_spec.rb
+++ b/spec/shale/type/time_spec.rb
@@ -138,4 +138,8 @@ RSpec.describe Shale::Type::Time do
       end
     end
   end
+
+  it 'is a registered type' do
+    expect(Shale::Type.lookup(:time)).to eq(described_class)
+  end
 end

--- a/spec/shale/type_spec.rb
+++ b/spec/shale/type_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'shale/type'
+
+module ShaleTypeTesting
+  class ValidType < Shale::Type::Value
+  end
+
+  class ReplacementValidType < Shale::Type::Value
+  end
+
+  class InvalidType
+  end
+end
+
+RSpec.describe Shale::Type do
+  it 'registers a valid type value' do
+    klass = ShaleTypeTesting::ValidType
+
+    Shale::Type.register(:valid_type, klass)
+
+    expect(Shale::Type.lookup(:valid_type)).to eq(klass)
+  end
+
+  context 'when registering a type value with an existing type' do
+    before do
+      Shale::Type.register(:valid_type, ShaleTypeTesting::ValidType)
+    end
+
+    it 'replaces the existing type' do
+      replacement_klass = ShaleTypeTesting::ReplacementValidType
+
+      Shale::Type.register(:valid_type, replacement_klass)
+
+      expect(Shale::Type.lookup(:valid_type)).to eq(replacement_klass)
+    end
+  end
+
+  context 'when registering an invalid type value' do
+    it 'raises an error' do
+      klass = ShaleTypeTesting::InvalidType
+
+      expect do
+        Shale::Type.register(:invalid_type, klass)
+      end.to raise_error(Shale::NotATypeValueError)
+    end
+  end
+
+  context 'when looking up an unregistered type value' do
+    it 'raises an error' do
+      expect do
+        Shale::Type.lookup(:unknown_type)
+      end.to raise_error(Shale::UnknownTypeError)
+    end
+  end
+end


### PR DESCRIPTION
# Design

Introduces `Shale::Type.register` and `Shale::Type.lookup` that the `Shale::Mapper` uses to map a short symbol alias to a full `Shale::Type::Value` subclass.

Existing built-in types have been registered with aliases, with the following exceptions:
* `Shale::Type::Value` - base class, couldn't come up with a good use case why this would be used directly enough to warrant an alias
* `Shale::Type::Complex` - private API, shouldn't be used directly anyway

# Out of Scope

I left the lookups for the XML/JSON schema compiler and generation alone such that they continue to stamp in the full class name instead of the symbol alias, but can switch those if you'd prefer.

I was going to swap them, but felt that the `name` method returning something like `":string"` felt a bit more awkward than the full class name as it would need to have the `:` prefix.

Resolves #43.