### PR TITLE
Add "description" and "additionalProperties" to Schema JSONGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1421,12 +1421,12 @@ class PersonMapper < Shale::Mapper
   attribute :age, :integer
 
   json do
-    properties max_properties: 5
+    properties max_properties: 5, additional_properties: false
 
     map "first_name", to: :first_name, schema: { required: true }
     map "last_name", to: :last_name, schema: { required: true }
-    map "address", to: :age, schema: { max_length: 128 }
-    map "age", to: :age, schema: { minimum: 1, maximum: 150 }
+    map "address", to: :address, schema: { max_length: 128, description: "Street, home number, city and country" }
+    map "age", to: :age, schema: { minimum: 1, maximum: 150, description: "Person age" }
   end
 end
 
@@ -1444,7 +1444,6 @@ Shale::Schema.to_json(
 #   "$defs": {
 #     "Person": {
 #       "type": "object",
-#       "maxProperties": 5,
 #       "properties": {
 #         "first_name": {
 #           "type": "string"
@@ -1452,23 +1451,30 @@ Shale::Schema.to_json(
 #         "last_name": {
 #           "type": "string"
 #         },
-#         "age": {
-#           "type": [
-#             "integer",
-#             "null"
-#           ],
-#          "minimum": 1,
-#          "maximum": 150
-#        },
 #         "address": {
 #           "type": [
 #             "string",
 #             "null"
 #           ],
-#           "maxLength": 128
+#           "maxLength": 128,
+#           "description": "Street, home number, city and country"
+#         },
+#         "age": {
+#           "type": [
+#             "integer",
+#             "null"
+#           ],
+#           "minimum": 1,
+#           "maximum": 150,
+#           "description": "Person age"
 #         }
 #       },
-#       "required": ["first_name", "last_name"]
+#       "required": [
+#         "first_name",
+#         "last_name"
+#       ],
+#       "maxProperties": 5,
+#       "additionalProperties": false
 #     }
 #   }
 # }

--- a/lib/shale/mapping/dict_base.rb
+++ b/lib/shale/mapping/dict_base.rb
@@ -67,13 +67,15 @@ module Shale
       # @param [Integer] min_properties
       # @param [Integer] max_properties
       # @param [Hash] dependent_required
+      # @param [Boolean] additional_properties
       #
       # @api public
-      def properties(min_properties: nil, max_properties: nil, dependent_required: nil)
+      def properties(min_properties: nil, max_properties: nil, dependent_required: nil, additional_properties: nil)
         @root = {
           min_properties: min_properties,
           max_properties: max_properties,
           dependent_required: dependent_required,
+          additional_properties: additional_properties,
         }
       end
 

--- a/lib/shale/schema/json_generator/boolean.rb
+++ b/lib/shale/schema/json_generator/boolean.rb
@@ -15,7 +15,8 @@ module Shale
         #
         # @api private
         def as_type
-          { 'type' => 'boolean' }
+          { 'type' => 'boolean',
+            'description' => schema[:description] }.compact
         end
       end
     end

--- a/lib/shale/schema/json_generator/collection.rb
+++ b/lib/shale/schema/json_generator/collection.rb
@@ -46,7 +46,8 @@ module Shale
             'maxItems' => schema[:max_items],
             'uniqueItems' => schema[:unique],
             'minContains' => schema[:min_contains],
-            'maxContains' => schema[:max_contains] }.compact
+            'maxContains' => schema[:max_contains],
+            'description' => schema[:description] }.compact
         end
       end
     end

--- a/lib/shale/schema/json_generator/date.rb
+++ b/lib/shale/schema/json_generator/date.rb
@@ -15,7 +15,9 @@ module Shale
         #
         # @api private
         def as_type
-          { 'type' => 'string', 'format' => 'date' }
+          { 'type' => 'string',
+            'format' => 'date',
+            'description' => schema[:description] }.compact
         end
       end
     end

--- a/lib/shale/schema/json_generator/float.rb
+++ b/lib/shale/schema/json_generator/float.rb
@@ -20,7 +20,8 @@ module Shale
             'exclusiveMaximum' => schema[:exclusive_maximum],
             'minimum' => schema[:minimum],
             'maximum' => schema[:maximum],
-            'multipleOf' => schema[:multiple_of] }.compact
+            'multipleOf' => schema[:multiple_of],
+            'description' => schema[:description] }.compact
         end
       end
     end

--- a/lib/shale/schema/json_generator/integer.rb
+++ b/lib/shale/schema/json_generator/integer.rb
@@ -20,7 +20,8 @@ module Shale
             'exclusiveMaximum' => schema[:exclusive_maximum],
             'minimum' => schema[:minimum],
             'maximum' => schema[:maximum],
-            'multipleOf' => schema[:multiple_of] }.compact
+            'multipleOf' => schema[:multiple_of],
+            'description' => schema[:description] }.compact
         end
       end
     end

--- a/lib/shale/schema/json_generator/object.rb
+++ b/lib/shale/schema/json_generator/object.rb
@@ -40,6 +40,8 @@ module Shale
             'minProperties' => @root[:min_properties],
             'maxProperties' => @root[:max_properties],
             'dependentRequired' => @root[:dependent_required],
+            'description' => @root[:description],
+            'additionalProperties' => @root[:additional_properties],
           }.compact
         end
       end

--- a/lib/shale/schema/json_generator/string.rb
+++ b/lib/shale/schema/json_generator/string.rb
@@ -19,7 +19,8 @@ module Shale
             'format' => schema[:format],
             'minLength' => schema[:min_length],
             'maxLength' => schema[:max_length],
-            'pattern' => schema[:pattern] }.compact
+            'pattern' => schema[:pattern],
+            'description' => schema[:description] }.compact
         end
       end
     end

--- a/lib/shale/schema/json_generator/time.rb
+++ b/lib/shale/schema/json_generator/time.rb
@@ -15,7 +15,9 @@ module Shale
         #
         # @api private
         def as_type
-          { 'type' => 'string', 'format' => 'date-time' }
+          { 'type' => 'string',
+            'format' => 'date-time',
+            'description' => schema[:description] }.compact
         end
       end
     end

--- a/lib/shale/schema/json_generator/value.rb
+++ b/lib/shale/schema/json_generator/value.rb
@@ -15,7 +15,8 @@ module Shale
         #
         # @api private
         def as_type
-          { 'type' => %w[boolean integer number object string] }
+          { 'type' => %w[boolean integer number object string],
+            'description' => schema[:description] }.compact
         end
       end
     end

--- a/spec/shale/schema/json_generator/boolean_spec.rb
+++ b/spec/shale/schema/json_generator/boolean_spec.rb
@@ -5,8 +5,32 @@ require 'shale/schema/json_generator/boolean'
 RSpec.describe Shale::Schema::JSONGenerator::Boolean do
   describe '#as_type' do
     it 'returns JSON Schema fragment as Hash' do
-      expected = { 'type' => 'boolean' }
-      expect(described_class.new('foo').as_type).to eq(expected)
+      expect(described_class.new('foo').as_type).to eq({ 'type' => 'boolean' })
+    end
+
+    context 'when schema is passed' do
+      it 'can include string keywords from JSON schema' do
+        schema = {
+          description: 'Attribute description',
+        }
+        expected = {
+          'type' => 'boolean',
+          'description' => 'Attribute description',
+        }
+        expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
+      end
+
+      it 'can use a subset of schema keywords' do
+        schema = {}
+        expected = { 'type' => 'boolean' }
+        expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
+      end
+
+      it 'will not use keywords for other types' do
+        schema = { unique_items: true }
+        expected = { 'type' => 'boolean' }
+        expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
+      end
     end
   end
 end

--- a/spec/shale/schema/json_generator/collection_spec.rb
+++ b/spec/shale/schema/json_generator/collection_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Shale::Schema::JSONGenerator::Collection do
           unique: true,
           min_contains: 5,
           max_contains: 10,
+          description: 'Attribute description',
         }
         expected = {
           'type' => 'array',
@@ -35,7 +36,7 @@ RSpec.describe Shale::Schema::JSONGenerator::Collection do
           'uniqueItems' => true,
           'minContains' => 5,
           'maxContains' => 10,
-
+          'description' => 'Attribute description',
         }
         expect(described_class.new(type, schema: schema).as_json).to eq(expected)
       end

--- a/spec/shale/schema/json_generator/float_spec.rb
+++ b/spec/shale/schema/json_generator/float_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Shale::Schema::JSONGenerator::Float do
           minimum: 0,
           maximum: 100,
           multiple_of: 4,
+          description: 'Attribute description',
         }
         expected = {
           'type' => 'number',
@@ -25,6 +26,7 @@ RSpec.describe Shale::Schema::JSONGenerator::Float do
           'minimum' => 0,
           'maximum' => 100,
           'multipleOf' => 4,
+          'description' => 'Attribute description',
         }
         expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
       end

--- a/spec/shale/schema/json_generator/object_spec.rb
+++ b/spec/shale/schema/json_generator/object_spec.rb
@@ -53,12 +53,16 @@ RSpec.describe Shale::Schema::JSONGenerator::Object do
           'properties' => {
             'bar' => { 'type' => %w[boolean null] },
           },
+          'description' => 'Attribute description',
+          'additionalProperties' => false,
         }
 
         root = {
           min_properties: 1,
           max_properties: 5,
           dependent_required: { 'foo' => ['bar'] },
+          description: 'Attribute description',
+          additional_properties: false,
         }
 
         expect(described_class.new('foo', types, root).as_type).to eq(expected)

--- a/spec/shale/schema/json_generator/string_spec.rb
+++ b/spec/shale/schema/json_generator/string_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Shale::Schema::JSONGenerator::String do
           min_length: 5,
           max_length: 10,
           pattern: 'foo-bar',
+          description: 'Attribute description',
         }
         expected = {
           'type' => 'string',
@@ -22,6 +23,7 @@ RSpec.describe Shale::Schema::JSONGenerator::String do
           'minLength' => 5,
           'maxLength' => 10,
           'pattern' => 'foo-bar',
+          'description' => 'Attribute description',
         }
         expect(described_class.new('foo', schema: schema).as_type).to eq(expected)
       end


### PR DESCRIPTION
Schema JSONGenerator could generate now schema with "description" and "additionalProperties" (for root and objects).

Example with [additionalProperties from JSON Schema Website](https://json-schema.org/understanding-json-schema/reference/object#additionalproperties)

```
{
  "type": "object",
  "properties": {
    "number": { "type": "number" },
    "street_name": { "type": "string" },
    "street_type": { "enum": ["Street", "Avenue", "Boulevard"] }
  },
  "additionalProperties": false
}
``` 

Example with [description from JSON Schema Website](https://json-schema.org/learn/getting-started-step-by-step#add-the-properties-object):

```
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "$id": "https://example.com/product.schema.json",
  "title": "Product",
  "description": "A product from Acme's catalog",
  "type": "object",
  "properties": {
    "productId": {
      "description": "The unique identifier for a product",
      "type": "integer"
    }
  }
}
```