### PR TITLE
Fixes issue where multiples namespace prefixes like ns1 and ns10 are …

### DIFF
--- a/lib/shale/schema/xml_compiler.rb
+++ b/lib/shale/schema/xml_compiler.rb
@@ -422,7 +422,7 @@ module Shale
       # @api private
       def replace_ns_prefixes(type, namespaces)
         namespaces.each do |prefix, name|
-          type = type.sub(/^#{prefix}/, name)
+          type = type.sub(/^#{prefix}:/, "#{name}:")
         end
 
         if namespaces.key?('xmlns') && !type.include?(':')


### PR DESCRIPTION
…replaced wrongly

I have some XSD's where more than 10 namespaces are referenced and I get an error as it replaces ns2 from ns29:Something with a resolved namespace
