### PR TITLE
Adds BigDecimal mapper

### DIFF
--- a/lib/shale.rb
+++ b/lib/shale.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'yaml'
+require 'bigdecimal'
 
 require_relative 'shale/mapper'
 require_relative 'shale/adapter/json'
 require_relative 'shale/type'
 require_relative 'shale/type/boolean'
 require_relative 'shale/type/date'
+require_relative 'shale/type/decimal'
 require_relative 'shale/type/float'
 require_relative 'shale/type/integer'
 require_relative 'shale/type/string'

--- a/lib/shale/schema/compiler/decimal.rb
+++ b/lib/shale/schema/compiler/decimal.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Shale
+  module Schema
+    module Compiler
+      # Class that maps Schema type to Shale Decimal type
+      #
+      # @api private
+      class Decimal
+        # Return name of the Shale type
+        #
+        # @return [String]
+        #
+        # @api private
+        def name
+          'Shale::Type::Decimal'
+        end
+      end
+    end
+  end
+end

--- a/lib/shale/schema/xml_compiler.rb
+++ b/lib/shale/schema/xml_compiler.rb
@@ -6,6 +6,7 @@ require_relative '../../shale'
 require_relative '../error'
 require_relative 'compiler/boolean'
 require_relative 'compiler/date'
+require_relative 'compiler/decimal'
 require_relative 'compiler/float'
 require_relative 'compiler/integer'
 require_relative 'compiler/string'
@@ -103,9 +104,14 @@ module Shale
       # XML Schema "float" types
       # @api private
       XS_TYPE_FLOAT = [
-        "#{XS_NAMESPACE_URI}:decimal",
         "#{XS_NAMESPACE_URI}:float",
         "#{XS_NAMESPACE_URI}:double",
+      ].freeze
+
+      # XML Schema "decimal" types
+      # @api private
+      XS_TYPE_DECIMAL = [
+        "#{XS_NAMESPACE_URI}:decimal"
       ].freeze
 
       # XML Schema "integer" types
@@ -612,6 +618,8 @@ module Shale
           Compiler::Time.new
         elsif XS_TYPE_STRING.include?(type)
           Compiler::String.new
+        elsif XS_TYPE_DECIMAL.include?(type)
+          Compiler::Decimal.new
         elsif XS_TYPE_FLOAT.include?(type)
           Compiler::Float.new
         elsif XS_TYPE_INTEGER.include?(type)

--- a/lib/shale/schema/xml_generator.rb
+++ b/lib/shale/schema/xml_generator.rb
@@ -52,6 +52,7 @@ module Shale
       register_xml_type(Shale::Type::Boolean, 'boolean')
       register_xml_type(Shale::Type::Date, 'date')
       register_xml_type(Shale::Type::Float, 'decimal')
+      register_xml_type(Shale::Type::Decimal, 'decimal')
       register_xml_type(Shale::Type::Integer, 'integer')
       register_xml_type(Shale::Type::Time, 'dateTime')
       register_xml_type(Shale::Type::Value, 'anyType')

--- a/lib/shale/type/decimal.rb
+++ b/lib/shale/type/decimal.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative 'value'
+
+module Shale
+  module Type
+    # Cast value to BigDecimal
+    #
+    # @api public
+    class Decimal < Value
+      class << self
+        # @param [String, Float, Integer, nil] value Value to cast
+        #
+        # @return [BigDecimal, nil]
+        #
+        # @api private
+        def cast(value)
+          return if value.nil?
+
+          case value
+          when ::BigDecimal then value
+          when ::Float then BigDecimal(value, value.to_s.length)
+          else BigDecimal(value)
+          end
+        end
+
+        def as_json(value, **)
+          value.to_f
+        end
+
+        def as_yaml(value, **)
+          value.to_f
+        end
+
+        def as_csv(value, **)
+          value.to_f
+        end
+
+        def as_toml(value, **)
+          value.to_f
+        end
+
+        def as_xml_value(value, **)
+          value.to_s('F')
+        end
+      end
+    end
+
+    register(:decimal, Decimal)
+  end
+end

--- a/spec/shale/schema/compiler/decimal_spec.rb
+++ b/spec/shale/schema/compiler/decimal_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'shale/schema/compiler/decimal'
+
+RSpec.describe Shale::Schema::Compiler::Decimal do
+  describe '#name' do
+    it 'returns Shale type name' do
+      expect(described_class.new.name).to eq('Shale::Type::Decimal')
+    end
+  end
+end

--- a/spec/shale/schema/xml_compiler_spec.rb
+++ b/spec/shale/schema/xml_compiler_spec.rb
@@ -4,6 +4,7 @@ require 'shale/adapter/ox'
 require 'shale/adapter/rexml'
 require 'shale/schema/compiler/boolean'
 require 'shale/schema/compiler/date'
+require 'shale/schema/compiler/decimal'
 require 'shale/schema/compiler/float'
 require 'shale/schema/compiler/integer'
 require 'shale/schema/compiler/string'
@@ -812,6 +813,7 @@ RSpec.describe Shale::Schema::XMLCompiler do
           <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
             <xs:element name="complex1" type="complex1" />
             <xs:element name="complex2" type="complex2" />
+            <xs:element name="complex3" type="complex3" />
 
             <xs:simpleType name="customInt">
               <xs:restriction base="xs:integer">
@@ -840,6 +842,22 @@ RSpec.describe Shale::Schema::XMLCompiler do
                 </xs:simpleContent>
               </xs:complexType>
             </xs:element>
+
+            <xs:simpleType name="decimal125">
+              <xs:restriction base="xs:decimal">
+                <xs:fractionDigits value="5"/>
+                <xs:maxExclusive value="10000000"/>
+                <xs:minInclusive value="0"/>
+                <xs:totalDigits value="12"/>
+              </xs:restriction>
+            </xs:simpleType>
+            
+            <xs:complexType name="complex3">
+              <xs:simpleContent>
+                <xs:extension base="decimal125">
+                </xs:extension>
+              </xs:simpleContent>
+            </xs:complexType>
           </xs:schema>
         SCHEMA
       end
@@ -847,7 +865,7 @@ RSpec.describe Shale::Schema::XMLCompiler do
       it 'generates models' do
         models = described_class.new.as_models([schema])
 
-        expect(models.length).to eq(3)
+        expect(models.length).to eq(4)
 
         expect(models[0].id).to eq('shoesize')
         expect(models[0].name).to eq('Shoesize')
@@ -866,33 +884,44 @@ RSpec.describe Shale::Schema::XMLCompiler do
         expect(models[0].properties[1].prefix).to eq(nil)
         expect(models[0].properties[1].namespace).to eq(nil)
 
-        expect(models[1].id).to eq('complex2')
-        expect(models[1].name).to eq('Complex2')
-        expect(models[1].root).to eq('complex2')
-        expect(models[1].properties.length).to eq(2)
+        expect(models[1].id).to eq('complex3')
+        expect(models[1].name).to eq('Complex3')
+        expect(models[1].root).to eq('complex3')
+        expect(models[1].properties.length).to eq(1)
         expect(models[1].properties[0].mapping_name).to eq('content')
-        expect(models[1].properties[0].type).to be_a(Shale::Schema::Compiler::String)
+        expect(models[1].properties[0].type).to be_a(Shale::Schema::Compiler::Decimal)
         expect(models[1].properties[0].collection?).to eq(false)
         expect(models[1].properties[0].default).to eq(nil)
         expect(models[1].properties[0].prefix).to eq(nil)
         expect(models[1].properties[0].namespace).to eq(nil)
-        expect(models[1].properties[1].mapping_name).to eq('el1')
-        expect(models[1].properties[1].type).to be_a(Shale::Schema::Compiler::Integer)
-        expect(models[1].properties[1].collection?).to eq(false)
-        expect(models[1].properties[1].default).to eq(nil)
-        expect(models[1].properties[1].prefix).to eq(nil)
-        expect(models[1].properties[1].namespace).to eq(nil)
 
-        expect(models[2].id).to eq('complex1')
-        expect(models[2].name).to eq('Complex1')
-        expect(models[2].root).to eq('complex1')
-        expect(models[2].properties.length).to eq(1)
+        expect(models[2].id).to eq('complex2')
+        expect(models[2].name).to eq('Complex2')
+        expect(models[2].root).to eq('complex2')
+        expect(models[2].properties.length).to eq(2)
         expect(models[2].properties[0].mapping_name).to eq('content')
-        expect(models[2].properties[0].type).to be_a(Shale::Schema::Compiler::Integer)
+        expect(models[2].properties[0].type).to be_a(Shale::Schema::Compiler::String)
         expect(models[2].properties[0].collection?).to eq(false)
         expect(models[2].properties[0].default).to eq(nil)
         expect(models[2].properties[0].prefix).to eq(nil)
         expect(models[2].properties[0].namespace).to eq(nil)
+        expect(models[2].properties[1].mapping_name).to eq('el1')
+        expect(models[2].properties[1].type).to be_a(Shale::Schema::Compiler::Integer)
+        expect(models[2].properties[1].collection?).to eq(false)
+        expect(models[2].properties[1].default).to eq(nil)
+        expect(models[2].properties[1].prefix).to eq(nil)
+        expect(models[2].properties[1].namespace).to eq(nil)
+
+        expect(models[3].id).to eq('complex1')
+        expect(models[3].name).to eq('Complex1')
+        expect(models[3].root).to eq('complex1')
+        expect(models[3].properties.length).to eq(1)
+        expect(models[3].properties[0].mapping_name).to eq('content')
+        expect(models[3].properties[0].type).to be_a(Shale::Schema::Compiler::Integer)
+        expect(models[3].properties[0].collection?).to eq(false)
+        expect(models[3].properties[0].default).to eq(nil)
+        expect(models[3].properties[0].prefix).to eq(nil)
+        expect(models[3].properties[0].namespace).to eq(nil)
       end
     end
 

--- a/spec/shale/schema/xml_generator_spec.rb
+++ b/spec/shale/schema/xml_generator_spec.rb
@@ -37,6 +37,7 @@ module ShaleSchemaXMLGeneratorTesting
   class Root < Shale::Mapper
     attribute :boolean, :boolean
     attribute :date, :date
+    attribute :decimal, :decimal
     attribute :float, :float
     attribute :integer, :integer
     attribute :string, :string
@@ -45,6 +46,7 @@ module ShaleSchemaXMLGeneratorTesting
 
     attribute :boolean_default, :boolean, default: -> { true }
     attribute :date_default, :date, default: -> { Date.new(2021, 1, 1) }
+    attribute :decimal_default, :decimal, default: -> { BigDecimal('1.0') }
     attribute :float_default, :float, default: -> { 1.0 }
     attribute :integer_default, :integer, default: -> { 1 }
     attribute :string_default, :string, default: -> { 'string' }
@@ -55,6 +57,7 @@ module ShaleSchemaXMLGeneratorTesting
 
     attribute :boolean_collection, :boolean, collection: true
     attribute :date_collection, :date, collection: true
+    attribute :decimal_collection, :decimal, collection: true
     attribute :float_collection, :float, collection: true
     attribute :integer_collection, :integer, collection: true
     attribute :string_collection, :string, collection: true
@@ -77,6 +80,7 @@ module ShaleSchemaXMLGeneratorTesting
 
       map_element 'boolean', to: :boolean
       map_element 'date', to: :date
+      map_element 'decimal', to: :decimal
       map_element 'float', to: :float
       map_element 'integer', to: :integer
       map_element 'string', to: :string
@@ -85,6 +89,7 @@ module ShaleSchemaXMLGeneratorTesting
 
       map_element 'boolean_default', to: :boolean_default
       map_element 'date_default', to: :date_default
+      map_element 'decimal_default', to: :decimal_default
       map_element 'float_default', to: :float_default
       map_element 'integer_default', to: :integer_default
       map_element 'string_default', to: :string_default
@@ -93,6 +98,7 @@ module ShaleSchemaXMLGeneratorTesting
 
       map_element 'boolean_collection', to: :boolean_collection
       map_element 'date_collection', to: :date_collection
+      map_element 'decimal_collection', to: :decimal_collection
       map_element 'float_collection', to: :float_collection
       map_element 'integer_collection', to: :integer_collection
       map_element 'string_collection', to: :string_collection
@@ -172,6 +178,7 @@ RSpec.describe Shale::Schema::XMLGenerator do
           <xs:sequence>
             <xs:element name="boolean" type="xs:boolean" minOccurs="0"/>
             <xs:element name="date" type="xs:date" minOccurs="0"/>
+            <xs:element name="decimal" type="xs:decimal" minOccurs="0"/>
             <xs:element name="float" type="xs:decimal" minOccurs="0"/>
             <xs:element name="integer" type="xs:integer" minOccurs="0"/>
             <xs:element name="string" type="xs:string" minOccurs="0"/>
@@ -179,6 +186,7 @@ RSpec.describe Shale::Schema::XMLGenerator do
             <xs:element name="value" type="xs:anyType" minOccurs="0"/>
             <xs:element name="boolean_default" type="xs:boolean" minOccurs="0" default="true"/>
             <xs:element name="date_default" type="xs:date" minOccurs="0" default="2021-01-01"/>
+            <xs:element name="decimal_default" type="xs:decimal" minOccurs="0" default="1.0"/>
             <xs:element name="float_default" type="xs:decimal" minOccurs="0" default="1.0"/>
             <xs:element name="integer_default" type="xs:integer" minOccurs="0" default="1"/>
             <xs:element name="string_default" type="xs:string" minOccurs="0" default="string"/>
@@ -186,6 +194,7 @@ RSpec.describe Shale::Schema::XMLGenerator do
             <xs:element name="value_default" type="xs:anyType" minOccurs="0" default="value"/>
             <xs:element name="boolean_collection" type="xs:boolean" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="date_collection" type="xs:date" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="decimal_collection" type="xs:decimal" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="float_collection" type="xs:decimal" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="integer_collection" type="xs:integer" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="string_collection" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>

--- a/spec/shale/type/complex_spec/with_types_spec.rb
+++ b/spec/shale/type/complex_spec/with_types_spec.rb
@@ -9,6 +9,7 @@ module ComplexSpec__Types # rubocop:disable Naming/ClassAndModuleCamelCase
   class Child < Shale::Mapper
     attribute :type_boolean, Shale::Type::Boolean
     attribute :type_date, Shale::Type::Date
+    attribute :type_decimal, Shale::Type::Decimal
     attribute :type_float, Shale::Type::Float
     attribute :type_integer, Shale::Type::Integer
     attribute :type_string, Shale::Type::String
@@ -19,6 +20,7 @@ module ComplexSpec__Types # rubocop:disable Naming/ClassAndModuleCamelCase
   class Root < Shale::Mapper
     attribute :type_boolean, Shale::Type::Boolean
     attribute :type_date, Shale::Type::Date
+    attribute :type_decimal, Shale::Type::Decimal
     attribute :type_float, Shale::Type::Float
     attribute :type_integer, Shale::Type::Integer
     attribute :type_string, Shale::Type::String
@@ -28,6 +30,7 @@ module ComplexSpec__Types # rubocop:disable Naming/ClassAndModuleCamelCase
 
     attribute :type_boolean_collection, Shale::Type::Boolean, collection: true
     attribute :type_date_collection, Shale::Type::Date, collection: true
+    attribute :type_decimal_collection, Shale::Type::Decimal, collection: true
     attribute :type_float_collection, Shale::Type::Float, collection: true
     attribute :type_integer_collection, Shale::Type::Integer, collection: true
     attribute :type_string_collection, Shale::Type::String, collection: true
@@ -38,6 +41,7 @@ module ComplexSpec__Types # rubocop:disable Naming/ClassAndModuleCamelCase
     csv do
       map 'type_boolean', to: :type_boolean
       map 'type_date', to: :type_date
+      map 'type_decimal', to: :type_decimal
       map 'type_float', to: :type_float
       map 'type_integer', to: :type_integer
       map 'type_string', to: :type_string
@@ -59,11 +63,76 @@ RSpec.describe Shale::Type::Complex do
   let(:mapper) { ComplexSpec__Types::Root }
 
   context 'with types' do
+    shared_examples 'maps to object' do
+      it 'maps to object' do
+        expect(instance.type_boolean).to eq(true)
+        expect(instance.type_date).to eq(Date.new(2022, 1, 1))
+        expect(instance.type_decimal).to eq(BigDecimal('1.1'))
+        expect(instance.type_float).to eq(1.1)
+        expect(instance.type_integer).to eq(1)
+        expect(instance.type_string).to eq('foo')
+        expect(instance.type_time).to eq(Time.new(2021, 1, 1, 10, 10, 10, '+01:00'))
+        expect(instance.type_value).to eq('foo')
+
+        expect(instance.child.type_boolean).to eq(true)
+        expect(instance.child.type_date).to eq(Date.new(2022, 1, 1))
+        expect(instance.child.type_decimal).to eq(BigDecimal('1.1'))
+        expect(instance.child.type_float).to eq(1.1)
+        expect(instance.child.type_integer).to eq(1)
+        expect(instance.child.type_string).to eq('foo')
+        expect(instance.child.type_time).to eq(Time.new(2021, 1, 1, 10, 10, 10, '+01:00'))
+        expect(instance.child.type_value).to eq('foo')
+
+        expect(instance.type_boolean_collection).to eq([true, false])
+        expect(instance.type_date_collection).to eq([
+                                                      Date.new(2022, 1, 1),
+                                                      Date.new(2022, 1, 2),
+                                                    ])
+        expect(instance.type_decimal_collection).to eq([BigDecimal('1.1'), BigDecimal('2.2')])
+        expect(instance.type_float_collection).to eq([1.1, 2.2])
+        expect(instance.type_integer_collection).to eq([1, 2])
+        expect(instance.type_string_collection).to eq(%w[foo bar])
+        expect(instance.type_time_collection).to eq([
+                                                      Time.new(2021, 1, 1, 10, 10, 10, '+01:00'),
+                                                      Time.new(2021, 1, 2, 10, 10, 10, '+01:00'),
+                                                    ])
+        # expect(instance.type_value_collection).to eq(['foo', 1, true])
+
+        expect(instance.child_collection[0].type_boolean).to eq(true)
+        expect(instance.child_collection[0].type_date).to eq(Date.new(2022, 1, 1))
+        expect(instance.child_collection[0].type_decimal).to eq(BigDecimal('1.1'))
+        expect(instance.child_collection[0].type_float).to eq(1.1)
+        expect(instance.child_collection[0].type_integer).to eq(1)
+        expect(instance.child_collection[0].type_string).to eq('foo')
+        expect(instance.child_collection[0].type_time).to eq(
+                                                            Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
+                                                          )
+        expect(instance.child_collection[0].type_value).to eq('foo')
+
+        expect(instance.child_collection[1].type_boolean).to eq(true)
+        expect(instance.child_collection[1].type_date).to eq(Date.new(2022, 1, 1))
+        expect(instance.child_collection[1].type_decimal).to eq(BigDecimal('1.1'))
+        expect(instance.child_collection[1].type_float).to eq(1.1)
+        expect(instance.child_collection[1].type_integer).to eq(1)
+        expect(instance.child_collection[1].type_string).to eq('foo')
+        expect(instance.child_collection[1].type_time).to eq(
+                                                            Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
+                                                          )
+        expect(instance.child_collection[1].type_value).to eq('foo')
+      end
+    end
+    shared_examples 'maps value collection to object' do
+      it 'maps value collection to object' do
+        expect(instance.type_value_collection).to eq(['foo', 1, true])
+      end
+    end
+
     context 'with hash mapping' do
       let(:hash) do
         {
           'type_boolean' => true,
           'type_date' => Date.new(2022, 1, 1),
+          'type_decimal' => BigDecimal('1.1'),
           'type_float' => 1.1,
           'type_integer' => 1,
           'type_string' => 'foo',
@@ -72,6 +141,7 @@ RSpec.describe Shale::Type::Complex do
           'child' => {
             'type_boolean' => true,
             'type_date' => Date.new(2022, 1, 1),
+            'type_decimal' => BigDecimal('1.1'),
             'type_float' => 1.1,
             'type_integer' => 1,
             'type_string' => 'foo',
@@ -80,6 +150,7 @@ RSpec.describe Shale::Type::Complex do
           },
           'type_boolean_collection' => [true, false],
           'type_date_collection' => [Date.new(2022, 1, 1), Date.new(2022, 1, 2)],
+          'type_decimal_collection' => [BigDecimal('1.1'), BigDecimal('2.2')],
           'type_float_collection' => [1.1, 2.2],
           'type_integer_collection' => [1, 2],
           'type_string_collection' => %w[foo bar],
@@ -92,6 +163,7 @@ RSpec.describe Shale::Type::Complex do
             {
               'type_boolean' => true,
               'type_date' => Date.new(2022, 1, 1),
+              'type_decimal' => BigDecimal('1.1'),
               'type_float' => 1.1,
               'type_integer' => 1,
               'type_string' => 'foo',
@@ -101,6 +173,7 @@ RSpec.describe Shale::Type::Complex do
             {
               'type_boolean' => true,
               'type_date' => Date.new(2022, 1, 1),
+              'type_decimal' => BigDecimal('1.1'),
               'type_float' => 1.1,
               'type_integer' => 1,
               'type_string' => 'foo',
@@ -110,67 +183,14 @@ RSpec.describe Shale::Type::Complex do
           ],
         }
       end
+      let(:instance) { mapper.from_hash(hash) }
 
       describe '.from_hash' do
-        it 'maps hash to object' do
-          instance = mapper.from_hash(hash)
-
-          expect(instance.type_boolean).to eq(true)
-          expect(instance.type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.type_float).to eq(1.1)
-          expect(instance.type_integer).to eq(1)
-          expect(instance.type_string).to eq('foo')
-          expect(instance.type_time).to eq(Time.new(2021, 1, 1, 10, 10, 10, '+01:00'))
-          expect(instance.type_value).to eq('foo')
-
-          expect(instance.child.type_boolean).to eq(true)
-          expect(instance.child.type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child.type_float).to eq(1.1)
-          expect(instance.child.type_integer).to eq(1)
-          expect(instance.child.type_string).to eq('foo')
-          expect(instance.child.type_time).to eq(Time.new(2021, 1, 1, 10, 10, 10, '+01:00'))
-          expect(instance.child.type_value).to eq('foo')
-
-          expect(instance.type_boolean_collection).to eq([true, false])
-          expect(instance.type_date_collection).to eq([
-            Date.new(2022, 1, 1),
-            Date.new(2022, 1, 2),
-          ])
-          expect(instance.type_float_collection).to eq([1.1, 2.2])
-          expect(instance.type_integer_collection).to eq([1, 2])
-          expect(instance.type_string_collection).to eq(%w[foo bar])
-          expect(instance.type_time_collection).to eq([
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00'),
-            Time.new(2021, 1, 2, 10, 10, 10, '+01:00'),
-          ])
-          expect(instance.type_value_collection).to eq(['foo', 1, true])
-
-          expect(instance.child_collection[0].type_boolean).to eq(true)
-          expect(instance.child_collection[0].type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child_collection[0].type_float).to eq(1.1)
-          expect(instance.child_collection[0].type_integer).to eq(1)
-          expect(instance.child_collection[0].type_string).to eq('foo')
-          expect(instance.child_collection[0].type_time).to eq(
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
-          )
-          expect(instance.child_collection[0].type_value).to eq('foo')
-
-          expect(instance.child_collection[1].type_boolean).to eq(true)
-          expect(instance.child_collection[1].type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child_collection[1].type_float).to eq(1.1)
-          expect(instance.child_collection[1].type_integer).to eq(1)
-          expect(instance.child_collection[1].type_string).to eq('foo')
-          expect(instance.child_collection[1].type_time).to eq(
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
-          )
-          expect(instance.child_collection[1].type_value).to eq('foo')
-        end
+        include_examples 'maps to object'
       end
 
       describe '.to_hash' do
         it 'converts objects to hash' do
-          instance = mapper.from_hash(hash)
-
           result = instance.to_hash
           expect(result).to eq(hash)
         end
@@ -183,6 +203,7 @@ RSpec.describe Shale::Type::Complex do
           {
             "type_boolean": true,
             "type_date": "2022-01-01",
+            "type_decimal": 1.1,
             "type_float": 1.1,
             "type_integer": 1,
             "type_string": "foo",
@@ -191,6 +212,7 @@ RSpec.describe Shale::Type::Complex do
             "child": {
               "type_boolean": true,
               "type_date": "2022-01-01",
+              "type_decimal": 1.1,
               "type_float": 1.1,
               "type_integer": 1,
               "type_string": "foo",
@@ -204,6 +226,10 @@ RSpec.describe Shale::Type::Complex do
             "type_date_collection": [
               "2022-01-01",
               "2022-01-02"
+            ],
+            "type_decimal_collection": [
+              1.1,
+              2.2
             ],
             "type_float_collection": [
               1.1,
@@ -230,6 +256,7 @@ RSpec.describe Shale::Type::Complex do
               {
                 "type_boolean": true,
                 "type_date": "2022-01-01",
+                "type_decimal": 1.1,
                 "type_float": 1.1,
                 "type_integer": 1,
                 "type_string": "foo",
@@ -239,6 +266,7 @@ RSpec.describe Shale::Type::Complex do
               {
                 "type_boolean": true,
                 "type_date": "2022-01-01",
+                "type_decimal": 1.1,
                 "type_float": 1.1,
                 "type_integer": 1,
                 "type_string": "foo",
@@ -249,67 +277,15 @@ RSpec.describe Shale::Type::Complex do
           }
         DOC
       end
+      let(:instance) { mapper.from_json(json) }
 
       describe '.from_json' do
-        it 'maps JSON to object' do
-          instance = mapper.from_json(json)
-
-          expect(instance.type_boolean).to eq(true)
-          expect(instance.type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.type_float).to eq(1.1)
-          expect(instance.type_integer).to eq(1)
-          expect(instance.type_string).to eq('foo')
-          expect(instance.type_time).to eq(Time.new(2021, 1, 1, 10, 10, 10, '+01:00'))
-          expect(instance.type_value).to eq('foo')
-
-          expect(instance.child.type_boolean).to eq(true)
-          expect(instance.child.type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child.type_float).to eq(1.1)
-          expect(instance.child.type_integer).to eq(1)
-          expect(instance.child.type_string).to eq('foo')
-          expect(instance.child.type_time).to eq(Time.new(2021, 1, 1, 10, 10, 10, '+01:00'))
-          expect(instance.child.type_value).to eq('foo')
-
-          expect(instance.type_boolean_collection).to eq([true, false])
-          expect(instance.type_date_collection).to eq([
-            Date.new(2022, 1, 1),
-            Date.new(2022, 1, 2),
-          ])
-          expect(instance.type_float_collection).to eq([1.1, 2.2])
-          expect(instance.type_integer_collection).to eq([1, 2])
-          expect(instance.type_string_collection).to eq(%w[foo bar])
-          expect(instance.type_time_collection).to eq([
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00'),
-            Time.new(2021, 1, 2, 10, 10, 10, '+01:00'),
-          ])
-          expect(instance.type_value_collection).to eq(['foo', 1, true])
-
-          expect(instance.child_collection[0].type_boolean).to eq(true)
-          expect(instance.child_collection[0].type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child_collection[0].type_float).to eq(1.1)
-          expect(instance.child_collection[0].type_integer).to eq(1)
-          expect(instance.child_collection[0].type_string).to eq('foo')
-          expect(instance.child_collection[0].type_time).to eq(
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
-          )
-          expect(instance.child_collection[0].type_value).to eq('foo')
-
-          expect(instance.child_collection[1].type_boolean).to eq(true)
-          expect(instance.child_collection[1].type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child_collection[1].type_float).to eq(1.1)
-          expect(instance.child_collection[1].type_integer).to eq(1)
-          expect(instance.child_collection[1].type_string).to eq('foo')
-          expect(instance.child_collection[1].type_time).to eq(
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
-          )
-          expect(instance.child_collection[1].type_value).to eq('foo')
-        end
+        include_examples 'maps to object'
+        include_examples 'maps value collection to object'
       end
 
       describe '.to_json' do
         it 'converts objects to JSON' do
-          instance = mapper.from_json(json)
-
           result = instance.to_json(pretty: true)
           expect(result).to eq(json.gsub(/\n\z/, ''))
         end
@@ -322,6 +298,7 @@ RSpec.describe Shale::Type::Complex do
           ---
           type_boolean: true
           type_date: '2022-01-01'
+          type_decimal: 1.1
           type_float: 1.1
           type_integer: 1
           type_string: foo
@@ -330,6 +307,7 @@ RSpec.describe Shale::Type::Complex do
           child:
             type_boolean: true
             type_date: '2022-01-01'
+            type_decimal: 1.1
             type_float: 1.1
             type_integer: 1
             type_string: foo
@@ -341,6 +319,9 @@ RSpec.describe Shale::Type::Complex do
           type_date_collection:
           - '2022-01-01'
           - '2022-01-02'
+          type_decimal_collection:
+          - 1.1
+          - 2.2
           type_float_collection:
           - 1.1
           - 2.2
@@ -360,6 +341,7 @@ RSpec.describe Shale::Type::Complex do
           child_collection:
           - type_boolean: true
             type_date: '2022-01-01'
+            type_decimal: 1.1
             type_float: 1.1
             type_integer: 1
             type_string: foo
@@ -367,6 +349,7 @@ RSpec.describe Shale::Type::Complex do
             type_value: foo
           - type_boolean: true
             type_date: '2022-01-01'
+            type_decimal: 1.1
             type_float: 1.1
             type_integer: 1
             type_string: foo
@@ -374,67 +357,15 @@ RSpec.describe Shale::Type::Complex do
             type_value: foo
         DOC
       end
+      let(:instance) { mapper.from_yaml(yaml) }
 
       describe '.from_yaml' do
-        it 'maps YAML to object' do
-          instance = mapper.from_yaml(yaml)
-
-          expect(instance.type_boolean).to eq(true)
-          expect(instance.type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.type_float).to eq(1.1)
-          expect(instance.type_integer).to eq(1)
-          expect(instance.type_string).to eq('foo')
-          expect(instance.type_time).to eq(Time.new(2021, 1, 1, 10, 10, 10, '+01:00'))
-          expect(instance.type_value).to eq('foo')
-
-          expect(instance.child.type_boolean).to eq(true)
-          expect(instance.child.type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child.type_float).to eq(1.1)
-          expect(instance.child.type_integer).to eq(1)
-          expect(instance.child.type_string).to eq('foo')
-          expect(instance.child.type_time).to eq(Time.new(2021, 1, 1, 10, 10, 10, '+01:00'))
-          expect(instance.child.type_value).to eq('foo')
-
-          expect(instance.type_boolean_collection).to eq([true, false])
-          expect(instance.type_date_collection).to eq([
-            Date.new(2022, 1, 1),
-            Date.new(2022, 1, 2),
-          ])
-          expect(instance.type_float_collection).to eq([1.1, 2.2])
-          expect(instance.type_integer_collection).to eq([1, 2])
-          expect(instance.type_string_collection).to eq(%w[foo bar])
-          expect(instance.type_time_collection).to eq([
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00'),
-            Time.new(2021, 1, 2, 10, 10, 10, '+01:00'),
-          ])
-          expect(instance.type_value_collection).to eq(['foo', 1, true])
-
-          expect(instance.child_collection[0].type_boolean).to eq(true)
-          expect(instance.child_collection[0].type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child_collection[0].type_float).to eq(1.1)
-          expect(instance.child_collection[0].type_integer).to eq(1)
-          expect(instance.child_collection[0].type_string).to eq('foo')
-          expect(instance.child_collection[0].type_time).to eq(
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
-          )
-          expect(instance.child_collection[0].type_value).to eq('foo')
-
-          expect(instance.child_collection[1].type_boolean).to eq(true)
-          expect(instance.child_collection[1].type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child_collection[1].type_float).to eq(1.1)
-          expect(instance.child_collection[1].type_integer).to eq(1)
-          expect(instance.child_collection[1].type_string).to eq('foo')
-          expect(instance.child_collection[1].type_time).to eq(
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
-          )
-          expect(instance.child_collection[1].type_value).to eq('foo')
-        end
+        include_examples 'maps to object'
+        include_examples 'maps value collection to object'
       end
 
       describe '.to_yaml' do
         it 'converts objects to YAML' do
-          instance = mapper.from_yaml(yaml)
-
           result = instance.to_yaml
           expect(result).to eq(yaml)
         end
@@ -446,6 +377,7 @@ RSpec.describe Shale::Type::Complex do
         <<~DOC
           type_boolean = true
           type_date = 2022-01-01
+          type_decimal = 1.1
           type_float = 1.1
           type_integer = 1
           type_string = "foo"
@@ -453,6 +385,7 @@ RSpec.describe Shale::Type::Complex do
           type_value = "foo"
           type_boolean_collection = [ true, false ]
           type_date_collection = [ 2022-01-01, 2022-01-02 ]
+          type_decimal_collection = [ 1.1, 2.2 ]
           type_float_collection = [ 1.1, 2.2 ]
           type_integer_collection = [ 1, 2 ]
           type_string_collection = [ "foo", "bar" ]
@@ -462,6 +395,7 @@ RSpec.describe Shale::Type::Complex do
           [child]
           type_boolean = true
           type_date = 2022-01-01
+          type_decimal = 1.1
           type_float = 1.1
           type_integer = 1
           type_string = "foo"
@@ -471,6 +405,7 @@ RSpec.describe Shale::Type::Complex do
           [[child_collection]]
           type_boolean = true
           type_date = 2022-01-01
+          type_decimal = 1.1
           type_float = 1.1
           type_integer = 1
           type_string = "foo"
@@ -480,6 +415,7 @@ RSpec.describe Shale::Type::Complex do
           [[child_collection]]
           type_boolean = true
           type_date = 2022-01-01
+          type_decimal = 1.1
           type_float = 1.1
           type_integer = 1
           type_string = "foo"
@@ -487,67 +423,15 @@ RSpec.describe Shale::Type::Complex do
           type_value = "foo"
         DOC
       end
+      let(:instance) { mapper.from_toml(toml) }
 
       describe '.from_toml' do
-        it 'maps TOML to object' do
-          instance = mapper.from_toml(toml)
-
-          expect(instance.type_boolean).to eq(true)
-          expect(instance.type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.type_float).to eq(1.1)
-          expect(instance.type_integer).to eq(1)
-          expect(instance.type_string).to eq('foo')
-          expect(instance.type_time).to eq(Time.new(2021, 1, 1, 10, 10, 10, '+01:00'))
-          expect(instance.type_value).to eq('foo')
-
-          expect(instance.child.type_boolean).to eq(true)
-          expect(instance.child.type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child.type_float).to eq(1.1)
-          expect(instance.child.type_integer).to eq(1)
-          expect(instance.child.type_string).to eq('foo')
-          expect(instance.child.type_time).to eq(Time.new(2021, 1, 1, 10, 10, 10, '+01:00'))
-          expect(instance.child.type_value).to eq('foo')
-
-          expect(instance.type_boolean_collection).to eq([true, false])
-          expect(instance.type_date_collection).to eq([
-            Date.new(2022, 1, 1),
-            Date.new(2022, 1, 2),
-          ])
-          expect(instance.type_float_collection).to eq([1.1, 2.2])
-          expect(instance.type_integer_collection).to eq([1, 2])
-          expect(instance.type_string_collection).to eq(%w[foo bar])
-          expect(instance.type_time_collection).to eq([
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00'),
-            Time.new(2021, 1, 2, 10, 10, 10, '+01:00'),
-          ])
-          expect(instance.type_value_collection).to eq(['foo', 1, true])
-
-          expect(instance.child_collection[0].type_boolean).to eq(true)
-          expect(instance.child_collection[0].type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child_collection[0].type_float).to eq(1.1)
-          expect(instance.child_collection[0].type_integer).to eq(1)
-          expect(instance.child_collection[0].type_string).to eq('foo')
-          expect(instance.child_collection[0].type_time).to eq(
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
-          )
-          expect(instance.child_collection[0].type_value).to eq('foo')
-
-          expect(instance.child_collection[1].type_boolean).to eq(true)
-          expect(instance.child_collection[1].type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child_collection[1].type_float).to eq(1.1)
-          expect(instance.child_collection[1].type_integer).to eq(1)
-          expect(instance.child_collection[1].type_string).to eq('foo')
-          expect(instance.child_collection[1].type_time).to eq(
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
-          )
-          expect(instance.child_collection[1].type_value).to eq('foo')
-        end
+        include_examples 'maps to object'
+        include_examples 'maps value collection to object'
       end
 
       describe '.to_toml' do
         it 'converts objects to TOML' do
-          instance = mapper.from_toml(toml)
-
           result = instance.to_toml
           expect(result).to eq(toml)
         end
@@ -557,7 +441,7 @@ RSpec.describe Shale::Type::Complex do
     context 'with CSV mapping' do
       let(:csv) do
         <<~DOC
-          true,2022-01-01,1.1,1,foo,2021-01-01T10:10:10+01:00,foo
+          true,2022-01-01,1.1,1.1,1,foo,2021-01-01T10:10:10+01:00,foo
         DOC
       end
 
@@ -567,6 +451,7 @@ RSpec.describe Shale::Type::Complex do
 
           expect(instance.type_boolean).to eq(true)
           expect(instance.type_date).to eq(Date.new(2022, 1, 1))
+          expect(instance.type_decimal).to eq(BigDecimal('1.1'))
           expect(instance.type_float).to eq(1.1)
           expect(instance.type_integer).to eq(1)
           expect(instance.type_string).to eq('foo')
@@ -591,6 +476,7 @@ RSpec.describe Shale::Type::Complex do
           <root>
             <type_boolean>true</type_boolean>
             <type_date>2022-01-01</type_date>
+            <type_decimal>1.1</type_decimal>
             <type_float>1.1</type_float>
             <type_integer>1</type_integer>
             <type_string>foo</type_string>
@@ -599,6 +485,7 @@ RSpec.describe Shale::Type::Complex do
             <child>
               <type_boolean>true</type_boolean>
               <type_date>2022-01-01</type_date>
+              <type_decimal>1.1</type_decimal>
               <type_float>1.1</type_float>
               <type_integer>1</type_integer>
               <type_string>foo</type_string>
@@ -609,6 +496,8 @@ RSpec.describe Shale::Type::Complex do
             <type_boolean_collection>false</type_boolean_collection>
             <type_date_collection>2022-01-01</type_date_collection>
             <type_date_collection>2022-01-02</type_date_collection>
+            <type_decimal_collection>1.1</type_decimal_collection>
+            <type_decimal_collection>2.2</type_decimal_collection>
             <type_float_collection>1.1</type_float_collection>
             <type_float_collection>2.2</type_float_collection>
             <type_integer_collection>1</type_integer_collection>
@@ -623,6 +512,7 @@ RSpec.describe Shale::Type::Complex do
             <child_collection>
               <type_boolean>true</type_boolean>
               <type_date>2022-01-01</type_date>
+              <type_decimal>1.1</type_decimal>
               <type_float>1.1</type_float>
               <type_integer>1</type_integer>
               <type_string>foo</type_string>
@@ -632,6 +522,7 @@ RSpec.describe Shale::Type::Complex do
             <child_collection>
               <type_boolean>true</type_boolean>
               <type_date>2022-01-01</type_date>
+              <type_decimal>1.1</type_decimal>
               <type_float>1.1</type_float>
               <type_integer>1</type_integer>
               <type_string>foo</type_string>
@@ -641,67 +532,18 @@ RSpec.describe Shale::Type::Complex do
           </root>
         DOC
       end
+      let(:instance) { mapper.from_xml(xml) }
 
       describe '.from_xml' do
-        it 'maps XML to object' do
-          instance = mapper.from_xml(xml)
+        include_examples 'maps to object'
 
-          expect(instance.type_boolean).to eq(true)
-          expect(instance.type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.type_float).to eq(1.1)
-          expect(instance.type_integer).to eq(1)
-          expect(instance.type_string).to eq('foo')
-          expect(instance.type_time).to eq(Time.new(2021, 1, 1, 10, 10, 10, '+01:00'))
-          expect(instance.type_value).to eq('foo')
-
-          expect(instance.child.type_boolean).to eq(true)
-          expect(instance.child.type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child.type_float).to eq(1.1)
-          expect(instance.child.type_integer).to eq(1)
-          expect(instance.child.type_string).to eq('foo')
-          expect(instance.child.type_time).to eq(Time.new(2021, 1, 1, 10, 10, 10, '+01:00'))
-          expect(instance.child.type_value).to eq('foo')
-
-          expect(instance.type_boolean_collection).to eq([true, false])
-          expect(instance.type_date_collection).to eq([
-            Date.new(2022, 1, 1),
-            Date.new(2022, 1, 2),
-          ])
-          expect(instance.type_float_collection).to eq([1.1, 2.2])
-          expect(instance.type_integer_collection).to eq([1, 2])
-          expect(instance.type_string_collection).to eq(%w[foo bar])
-          expect(instance.type_time_collection).to eq([
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00'),
-            Time.new(2021, 1, 2, 10, 10, 10, '+01:00'),
-          ])
+        it 'maps value collection to object as strings' do
           expect(instance.type_value_collection).to eq(%w[foo 1 true])
-
-          expect(instance.child_collection[0].type_boolean).to eq(true)
-          expect(instance.child_collection[0].type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child_collection[0].type_float).to eq(1.1)
-          expect(instance.child_collection[0].type_integer).to eq(1)
-          expect(instance.child_collection[0].type_string).to eq('foo')
-          expect(instance.child_collection[0].type_time).to eq(
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
-          )
-          expect(instance.child_collection[0].type_value).to eq('foo')
-
-          expect(instance.child_collection[1].type_boolean).to eq(true)
-          expect(instance.child_collection[1].type_date).to eq(Date.new(2022, 1, 1))
-          expect(instance.child_collection[1].type_float).to eq(1.1)
-          expect(instance.child_collection[1].type_integer).to eq(1)
-          expect(instance.child_collection[1].type_string).to eq('foo')
-          expect(instance.child_collection[1].type_time).to eq(
-            Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
-          )
-          expect(instance.child_collection[1].type_value).to eq('foo')
         end
       end
 
       describe '.to_xml' do
         it 'converts objects to XML' do
-          instance = mapper.from_xml(xml)
-
           result = instance.to_xml(pretty: true)
           expect(result).to eq(xml.gsub(/\n\z/, ''))
         end

--- a/spec/shale/type/decimal_spec.rb
+++ b/spec/shale/type/decimal_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'shale/type/decimal'
+
+RSpec.describe Shale::Type::Decimal do
+  describe '.cast' do
+    context 'when value is nil' do
+      it 'returns nil' do
+        expect(described_class.cast(nil)).to eq(nil)
+      end
+    end
+
+    context 'when value is float' do
+      it 'returns BigDecimal number' do
+        expect(described_class.cast(123.123)).to eq(BigDecimal("123.123"))
+        expect(described_class.cast(123.33)).to eq(BigDecimal("123.33"))
+      end
+    end
+
+    context 'when value is Infinity' do
+      it 'returns BigDecimal number' do
+        expect(described_class.cast('Infinity')).to eq(BigDecimal('Infinity'))
+      end
+    end
+
+    context 'when value is -Infinity' do
+      it 'returns BigDecimal number' do
+        expect(described_class.cast('-Infinity')).to eq(BigDecimal('-Infinity'))
+      end
+    end
+
+    context 'when value is NaN' do
+      it 'returns BigDecimal NaN' do
+        expect(described_class.cast('NaN').nan?).to eq(true)
+      end
+    end
+
+    context 'when value is anything other' do
+      it 'returns BigDecimal value' do
+        expect(described_class.cast('123.123')).to eq(BigDecimal("123.123"))
+      end
+    end
+  end
+
+  it 'is a registered type' do
+    expect(Shale::Type.lookup(:decimal)).to eq(described_class)
+  end
+end


### PR DESCRIPTION
Adds Decimal mapper type
Shale Mappers generated from XSD's will use the Decimal mapper type to preserve the precision
when reading decimal values from XML documents instead of converting them to floats.

When the mapper is used for mapping other formats than XML the internal BigDecimal values are converted to floats
as they would otherwise be written as strings in output documents.

It should be possible to modify this in the future if the underlying serializers can handle BigDecimals.

I have added tests but I refactored the "maps xxx to object" examples into a shared example to reduce the repetition. It got a bit awkward though because of the value_collection mapping being handled differently