### PR TITLE
Bugfix/define schema for shale mapper objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [unreleased]
+
+### Fixed
+- [ollietulloch] Allow `Shale::Mapper` attributes to define a `schema`
+
 ## [1.2.1] - 2025-01-09
 
 ### Fixed

--- a/lib/shale/schema/json_generator.rb
+++ b/lib/shale/schema/json_generator.rb
@@ -87,7 +87,7 @@ module Shale
             next unless attribute
 
             if mapper_type?(attribute.type)
-              json_type = Ref.new(mapping.name, attribute.type.model.name)
+              json_type = Ref.new(mapping.name, attribute.type.model.name, schema: mapping.schema)
             else
               json_klass = self.class.get_json_type(attribute.type)
 

--- a/lib/shale/schema/json_generator/ref.rb
+++ b/lib/shale/schema/json_generator/ref.rb
@@ -9,8 +9,8 @@ module Shale
       #
       # @api private
       class Ref < Base
-        def initialize(name, type)
-          super(name)
+        def initialize(name, type, schema: nil)
+          super(name, schema: schema)
           @type = type.gsub('::', '_')
         end
 

--- a/spec/shale/schema/json_generator_spec.rb
+++ b/spec/shale/schema/json_generator_spec.rb
@@ -83,6 +83,12 @@ module ShaleSchemaJSONGeneratorTesting
     attribute :first_name, :string
     attribute :last_name, :string
     attribute :address, AddressMapper
+
+    json do
+      map 'first_name', to: :first_name
+      map 'last_name', to: :last_name
+      map 'address', to: :address, schema: { required: true }
+    end
   end
 end
 
@@ -319,6 +325,7 @@ RSpec.describe Shale::Schema::JSONGenerator do
                 'last_name' => { 'type' => %w[string null] },
                 'address' => { '$ref' => '#/$defs/ShaleSchemaJSONGeneratorTesting_Address' },
               },
+              'required' => ['address'],
             },
           },
         }


### PR DESCRIPTION
This PR addresses a bug (#51) where JSON attributes that have a `type` which inherits from `Shale::Mapper` could not define their own `schema`, meaning these attributes could not be flagged as `required`,  for example.

