### PR TITLE
Add support for x-www-form-urlencoded format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /pkg/
 /coverage/
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,16 @@ gemspec
 gem 'rake', '~> 13.1'
 gem 'rubocop', '~> 1.60'
 
-gem 'rexml'
-gem 'nokogiri', '1.13.10'
-gem 'ox'
-gem 'toml-rb'
-gem 'tomlib'
+gem 'byebug'
 gem 'csv'
+gem 'irb'
+gem 'nokogiri', '1.13.10'
+gem 'ostruct'
+gem 'ox'
+gem 'rack'
+gem 'rexml'
+gem 'tomlib'
+gem 'toml-rb'
 
 group :test do
   gem 'rspec', '~> 3.13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,25 +9,52 @@ GEM
   specs:
     ast (2.4.2)
     bigdecimal (3.1.6)
+    byebug (13.0.0)
+      reline (>= 0.6.0)
     citrus (3.0.2)
     csv (3.2.8)
     diff-lcs (1.5.1)
     docile (1.4.0)
+    erb (6.0.6)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
+    logger (1.7.0)
     mini_portile2 (2.8.1)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    ostruct (0.6.3)
     ox (2.14.12)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
     racc (1.6.2)
+    rack (3.2.6)
     rainbow (3.1.1)
     rake (13.1.0)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
     regexp_parser (2.9.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
     rexml (3.2.5)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -65,18 +92,24 @@ GEM
     toml-rb (2.2.0)
       citrus (~> 3.0, > 3.0)
     tomlib (0.5.0)
+    tsort (0.2.0)
     unicode-display_width (2.5.0)
 
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES
+  byebug
   csv
+  irb
   nokogiri (= 1.13.10)
+  ostruct
   ox
+  rack
   rake (~> 13.1)
   rexml
   rspec (~> 3.13.0)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Shale
 
-Shale is a Ruby object mapper and serializer for JSON, YAML, TOML, CSV and XML.
-It allows you to parse JSON, YAML, TOML, CSV and XML data and convert it into Ruby data structures,
-as well as serialize data structures into JSON, YAML, TOML, CSV or XML.
+Shale is a Ruby object mapper and serializer for JSON, YAML, TOML, CSV, XML and x-www-form-urlencoded.
+It allows you to parse JSON, YAML, TOML, CSV, XML and x-www-form-urlencoded data and convert it into Ruby data structures,
+as well as serialize data structures into JSON, YAML, TOML, CSV, XML or x-www-form-urlencoded.
 
 Documentation with interactive examples is available at [Shale website](https://www.shalerb.org)
 
 ## Features
 
-* Convert JSON, YAML, TOML, CSV and XML to Ruby data model
-* Convert Ruby data model to JSON, YAML, TOML, CSV and XML
+* Convert JSON, YAML, TOML, CSV, XML and x-www-form-urlencoded to Ruby data model
+* Convert Ruby data model to JSON, YAML, TOML, CSV, XML and x-www-form-urlencoded
 * Generate JSON and XML Schema from Ruby models
 * Compile JSON and XML Schema into Ruby models
-* Out of the box support for JSON, YAML, Tomlib, toml-rb, CSV, Nokogiri, REXML and Ox parsers
+* Out of the box support for JSON, YAML, Tomlib, toml-rb, CSV, Nokogiri, REXML, Ox, Rack x-www-form-urlencoded parsers
 * Support for custom adapters
 
 ## Installation
@@ -53,10 +53,13 @@ $ gem install shale
 * [Converting object to XML](#converting-object-to-xml)
 * [Converting CSV to object](#converting-csv-to-object)
 * [Converting object to CSV](#converting-object-to-csv)
+* [Converting urlencoded to object](#converting-urlencoded-to-object)
+* [Converting object to urlencoded](#converting-object-to-urlencoded)
 * [Converting collections](#converting-collections)
 * [Mapping JSON keys to object attributes](#mapping-json-keys-to-object-attributes)
 * [Mapping YAML keys to object attributes](#mapping-yaml-keys-to-object-attributes)
 * [Mapping TOML keys to object attributes](#mapping-toml-keys-to-object-attributes)
+* [Mapping urlencoded keys to object attributes](#mapping-urlencoded-keys-to-object-attributes)
 * [Mapping CSV columns to object attributes](#mapping-csv-columns-to-object-attributes)
 * [Mapping Hash keys to object attributes](#mapping-hash-keys-to-object-attributes)
 * [Mapping XML elements and attributes to object attributes](#mapping-xml-elements-and-attributes-to-object-attributes)
@@ -396,6 +399,41 @@ people[0].to_csv # or Person.to_csv(people) if you want to convert a collection
 # John,Doe,50,false
 ```
 
+### Converting urlencoded to object
+
+To use x-www-form-urlencoded with Shale you have to set an adapter.
+Shale comes with adapter for [rack/utils](https://github.com/rack/rack).
+For details see [Adapters](#adapters) section.
+
+To set it, first make sure the `rack` gem is installed:
+
+```
+$ gem install rack
+```
+
+then setup the adapter:
+
+```ruby
+require 'shale/adapter/rack_url_encoded'
+Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
+```
+
+Now you can use x-www-form-urlencoded data with Shale.
+
+`.from_urlencoded` method always returns an array of records.
+
+```ruby
+person = Person.from_urlencoded("first_name=John&last_name=Doe&age=50&married=false")
+```
+
+### Converting object to urlencoded
+
+```ruby
+person.to_urlencoded
+
+# => "first_name=John&last_name=Doe&age=50&married=false"
+```
+
 ### Converting collections
 
 Shale allows converting collections for formats that support it (JSON, YAML and CSV).
@@ -475,6 +513,24 @@ class Person < Shale::Mapper
   attribute :last_name, :string
 
   toml do
+    map 'firstName', to: :first_name
+    map 'lastName', to: :last_name
+  end
+end
+```
+
+### Mapping urlencoded keys to object attributes
+
+By default keys are named the same as attributes. To use custom keys use:
+
+:warning: **Declaring custom mapping removes default mapping for given format!**
+
+```ruby
+class Person < Shale::Mapper
+  attribute :first_name, :string
+  attribute :last_name, :string
+
+  urlencoded do
     map 'firstName', to: :first_name
     map 'lastName', to: :last_name
   end
@@ -1325,6 +1381,14 @@ Shale.xml_adapter = Shale::Adapter::Nokogiri
 
 require 'shale/adapter/ox'
 Shale.xml_adapter = Shale::Adapter::Ox
+```
+
+To handle x-www-form-urlencoded documents you have to set the urlencoded adapter. Shale provides an adapter for the `rack/utils` parser:
+
+```ruby
+require 'shale'
+require 'shale/adapter/rack_url_encoded'
+Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
 ```
 
 ### Generating JSON Schema

--- a/lib/shale.rb
+++ b/lib/shale.rb
@@ -32,6 +32,10 @@ require_relative 'shale/version'
 #   Shale.json_adapter = MultiJson
 #   Shale.json_adapter # => MultiJson
 #
+# @example setting Rack::Utils for handling x-www-form-urlencoded documents
+#   Shale.urlencoded_adapter = RackURLEncoded
+#   Shale.urlencoded_adapter # => RackURLEncoded
+#
 # @example setting TOML adapter for handling TOML documents
 #   require 'shale/adapter/toml_rb'
 #
@@ -45,8 +49,8 @@ require_relative 'shale/version'
 # @example setting Nokogiri adapter for handling XML documents
 #   require 'shale/adapter/nokogiri'
 #
-#   Shale.xml_adapter = Shale::Adapter::Nokogir
-#   Shale.xml_adapter # => Shale::Adapter::Nokogir
+#   Shale.xml_adapter = Shale::Adapter::Nokogiri
+#   Shale.xml_adapter # => Shale::Adapter::Nokogiri
 #
 # @example setting Ox adapter for handling XML documents
 #   require 'shale/adapter/ox'
@@ -72,6 +76,16 @@ module Shale
     #
     # @api public
     attr_writer :json_adapter
+
+    # Set x-www-form-urlencoded adapter
+    #
+    # @param [.load, .dump] adapter
+    #
+    # @example
+    #   Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
+    #
+    # @api public
+    attr_accessor :urlencoded_adapter
 
     # Set YAML adapter
     #

--- a/lib/shale/adapter/rack_url_encoded.rb
+++ b/lib/shale/adapter/rack_url_encoded.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rack/utils'
+
+module Shale
+  module Adapter
+    # RackURLEncoded adapter. Adapter for url-encoded format using rack utils.
+    #
+    # @api public
+    class RackURLEncoded
+      # Synthetic key used to coax Rack into parsing a top-level array.
+      # Rack's parser always produces a Hash at the root and refuses to treat
+      # a leading "[]" as array nesting, so we prefix each pair with this key,
+      # let Rack build the array under it, then unwrap the result.
+      TOP_LEVEL_ARRAY_KEY = 'r'
+
+      class << self
+        # Parse x-www-form-urlencoded into Hash
+        #
+        # @param [String] text x-www-form-urlencoded text
+        # @param [Hash] options
+        #
+        # @return [Hash]
+        #
+        # @api private
+        def load(text, **_options)
+          return ::Rack::Utils.parse_nested_query(text) unless top_level_array?(text)
+
+          prefixed = text.split('&').map { |pair| "#{TOP_LEVEL_ARRAY_KEY}#{pair}" }.join('&')
+          ::Rack::Utils.parse_nested_query(prefixed)[TOP_LEVEL_ARRAY_KEY]
+        end
+
+        # Serialize Hash into x-www-form-urlencoded
+        #
+        # @param [Hash] obj Hash object
+        # @param [Hash] options
+        #
+        # @return [String]
+        #
+        # @api private
+        def dump(obj, **_options)
+          ::Rack::Utils.build_nested_query(obj)
+        end
+
+        private
+
+        # Detect whether the document encodes a top-level array. Such documents
+        # start with "[]" (escaped as "%5B%5D")
+        #
+        # @param [String] text x-www-form-urlencoded text
+        #
+        # @return [Boolean]
+        #
+        # @api private
+        def top_level_array?(text)
+          return false if text.nil? || text.empty?
+
+          text.start_with?('%5B%5D')
+        end
+      end
+    end
+  end
+end

--- a/lib/shale/mapper.rb
+++ b/lib/shale/mapper.rb
@@ -47,6 +47,7 @@ module Shale
     @model = nil
     @attributes = {}
     @hash_mapping = Mapping::Dict.new
+    @urlencoded_mapping = Mapping::Dict.new
     @json_mapping = Mapping::Dict.new
     @yaml_mapping = Mapping::Dict.new
     @toml_mapping = Mapping::Dict.new
@@ -67,6 +68,13 @@ module Shale
       #
       # @api public
       attr_reader :hash_mapping
+
+      # Return x-www-form-urlencoded mapping object
+      #
+      # @return [Shale::Mapping::Dict]
+      #
+      # @api public
+      attr_reader :urlencoded_mapping
 
       # Return JSON mapping object
       #
@@ -115,6 +123,7 @@ module Shale
         subclass.instance_variable_set('@attributes', @attributes.dup)
 
         subclass.instance_variable_set('@__hash_mapping_init', @hash_mapping.dup)
+        subclass.instance_variable_set('@__urlencoded_mapping_init', @urlencoded_mapping.dup)
         subclass.instance_variable_set('@__json_mapping_init', @json_mapping.dup)
         subclass.instance_variable_set('@__yaml_mapping_init', @yaml_mapping.dup)
         subclass.instance_variable_set('@__toml_mapping_init', @toml_mapping.dup)
@@ -122,6 +131,7 @@ module Shale
         subclass.instance_variable_set('@__xml_mapping_init', @xml_mapping.dup)
 
         subclass.instance_variable_set('@hash_mapping', @hash_mapping.dup)
+        subclass.instance_variable_set('@urlencoded_mapping', @urlencoded_mapping.dup)
         subclass.instance_variable_set('@json_mapping', @json_mapping.dup)
         subclass.instance_variable_set('@yaml_mapping', @yaml_mapping.dup)
         subclass.instance_variable_set('@toml_mapping', @toml_mapping.dup)
@@ -186,6 +196,7 @@ module Shale
         @attributes[name] = Attribute.new(name, type, collection, default)
 
         @hash_mapping.map(name.to_s, to: name) unless @hash_mapping.finalized?
+        @urlencoded_mapping.map(name.to_s, to: name) unless @urlencoded_mapping.finalized?
         @json_mapping.map(name.to_s, to: name) unless @json_mapping.finalized?
         @yaml_mapping.map(name.to_s, to: name) unless @yaml_mapping.finalized?
         @toml_mapping.map(name.to_s, to: name) unless @toml_mapping.finalized?
@@ -223,6 +234,30 @@ module Shale
         @hash_mapping = @__hash_mapping_init.dup
         @hash_mapping.finalize!
         @hash_mapping.instance_eval(&block)
+      end
+
+      # Define x-www-form-urlencoded mapping
+      #
+      # @param [Proc] block
+      #
+      # @example
+      #   class Person < Shale::Mapper
+      #     attribute :first_name, :string
+      #     attribute :last_name, :string
+      #     attribute :age, :integer
+      #
+      #     urlencoded do
+      #       map 'firstName', to: :first_name
+      #       map 'lastName', to: :last_name
+      #       map 'age', to: :age
+      #     end
+      #   end
+      #
+      # @api public
+      def urlencoded(&block)
+        @urlencoded_mapping = @__urlencoded_mapping_init.dup
+        @urlencoded_mapping.finalize!
+        @urlencoded_mapping.instance_eval(&block)
       end
 
       # Define JSON mapping

--- a/lib/shale/type/complex.rb
+++ b/lib/shale/type/complex.rb
@@ -1068,8 +1068,7 @@ module Shale
       # @param [Array<Symbol>] only
       # @param [Array<Symbol>] except
       # @param [any] context
-      # @param [true, false] pretty
-      # @param [Hash] json_options
+      # @param [Hash] urlencoded_options
       #
       # @return [String]
       #

--- a/lib/shale/type/complex.rb
+++ b/lib/shale/type/complex.rb
@@ -14,9 +14,9 @@ module Shale
     # @api private
     class Complex < Value
       class << self
-        %i[hash json yaml toml csv].each do |format|
+        %i[hash urlencoded json yaml toml csv].each do |format|
           class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-            # Convert Hash to Object using Hash/JSON/YAML/TOML mapping
+            # Convert Hash to Object using Hash/JSON/YAML/TOML/urlencoded mapping
             #
             # @param [Hash, Array] hash Hash to convert
             # @param [Array<Symbol>] only
@@ -136,7 +136,7 @@ module Shale
               instance
             end
 
-            # Convert Object to Hash using Hash/JSON/YAML/TOML mapping
+            # Convert Object to Hash using Hash/JSON/YAML/TOML/urlencoded mapping
             #
             # @param [any, Array<any>] instance Object to convert
             # @param [Array<Symbol>] only
@@ -287,6 +287,45 @@ module Shale
           Shale.json_adapter.dump(
             as_json(instance, only: only, except: except, context: context),
             **json_options.merge(pretty: pretty)
+          )
+        end
+
+        # Convert x-www-form-urlencoded to Object
+        #
+        # @param [String] urlencoded x-www-form-urlencoded text to convert
+        # @param [Array<Symbol>] only
+        # @param [Array<Symbol>] except
+        # @param [any] context
+        # @param [Hash] urlencoded_options
+        #
+        # @return [model instance]
+        #
+        # @api public
+        def from_urlencoded(urlencoded, only: nil, except: nil, context: nil, **urlencoded_options)
+          of_urlencoded(
+            Shale.urlencoded_adapter.load(urlencoded, **urlencoded_options),
+            only: only,
+            except: except,
+            context: context
+          )
+        end
+
+        # Convert Object to x-www-form-urlencoded
+        #
+        # @param [model instance] instance Object to convert
+        # @param [Array<Symbol>] only
+        # @param [Array<Symbol>] except
+        # @param [any] context
+        # @param [true, false] pretty
+        # @param [Hash] urlencoded_options
+        #
+        # @return [String]
+        #
+        # @api public
+        def to_urlencoded(instance, only: nil, except: nil, context: nil, pretty: false, **urlencoded_options)
+          Shale.urlencoded_adapter.dump(
+            as_urlencoded(instance, only: only, except: except, context: context),
+            **urlencoded_options.merge(pretty: pretty)
           )
         end
 
@@ -1021,6 +1060,27 @@ module Shale
           context: context,
           pretty: pretty,
           **json_options
+        )
+      end
+
+      # Convert Object to x-www-form-urlencoded
+      #
+      # @param [Array<Symbol>] only
+      # @param [Array<Symbol>] except
+      # @param [any] context
+      # @param [true, false] pretty
+      # @param [Hash] json_options
+      #
+      # @return [String]
+      #
+      # @api public
+      def to_urlencoded(only: nil, except: nil, context: nil, **urlencoded_options)
+        self.class.to_urlencoded(
+          self,
+          only: only,
+          except: except,
+          context: context,
+          **urlencoded_options
         )
       end
 

--- a/lib/shale/type/date.rb
+++ b/lib/shale/type/date.rb
@@ -58,6 +58,17 @@ module Shale
         value&.iso8601
       end
 
+      # Use ISO 8601 format in x-www-form-urlencoded document
+      #
+      # @param [Date] value
+      #
+      # @return [String]
+      #
+      # @api private
+      def self.as_urlencoded(value, **)
+        value&.iso8601
+      end
+
       # Use ISO 8601 format in XML document
       #
       # @param [Date] value Value to convert to XML

--- a/lib/shale/type/decimal.rb
+++ b/lib/shale/type/decimal.rb
@@ -36,6 +36,10 @@ module Shale
           value.to_f
         end
 
+        def as_urlencoded(value, **)
+          value.to_s('F')
+        end
+
         def as_toml(value, **)
           value.to_f
         end

--- a/lib/shale/type/time.rb
+++ b/lib/shale/type/time.rb
@@ -58,6 +58,17 @@ module Shale
         value&.iso8601
       end
 
+      # Use ISO 8601 format in x-www-form-urlencoded document
+      #
+      # @param [Time] value
+      #
+      # @return [String]
+      #
+      # @api private
+      def self.as_urlencoded(value, **)
+        value&.iso8601
+      end
+
       # Use ISO 8601 format in XML document
       #
       # @param [Time] value Value to convert to XML

--- a/lib/shale/type/value.rb
+++ b/lib/shale/type/value.rb
@@ -67,6 +67,28 @@ module Shale
           value
         end
 
+        # Extract value from x-www-form-urlencoded document
+        #
+        # @param [any] value
+        #
+        # @return [any]
+        #
+        # @api private
+        def of_urlencoded(value, **)
+          value
+        end
+
+        # Convert value to form accepted by x-www-form-urlencoded document
+        #
+        # @param [any] value
+        #
+        # @return [any]
+        #
+        # @api private
+        def as_urlencoded(value, **)
+          value.to_s
+        end
+
         # Extract value from YAML document
         #
         # @param [any] value

--- a/spec/shale/adapter/rack_url_encoded_spec.rb
+++ b/spec/shale/adapter/rack_url_encoded_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'shale/adapter/rack_url_encoded'
+
+RSpec.describe Shale::Adapter::RackURLEncoded do
+  describe '.load' do
+    it 'parses urlencoded document' do
+      doc = described_class.load('name=Alice&age=30')
+      expect(doc).to eq({ 'name' => 'Alice', 'age' => '30' })
+    end
+  end
+
+  describe '.dump' do
+    it 'generates urlencoded document' do
+      urlencoded = described_class.dump({ 'name' => 'Alice', 'age' => '30' })
+      expect(urlencoded).to eq('name=Alice&age=30')
+    end
+  end
+end

--- a/spec/shale/mapper_spec.rb
+++ b/spec/shale/mapper_spec.rb
@@ -24,6 +24,9 @@ module ShaleMapperTesting
     json do
     end
 
+    urlencoded do
+    end
+
     yaml do
     end
 
@@ -53,6 +56,10 @@ module ShaleMapperTesting
       map 'child3_bar', to: :child3_foo
     end
 
+    urlencoded do
+      map 'child3_bar', to: :child3_foo
+    end
+
     yaml do
       map 'child3_bar', to: :child3_foo
     end
@@ -75,6 +82,18 @@ module ShaleMapperTesting
     attribute :foo, :string
 
     hsh do
+      map 'bar', to: :foo
+      group from: :method_from, to: :method_to do
+        map 'baz'
+        map 'qux'
+      end
+    end
+  end
+
+  class UrlencodedMapping < Shale::Mapper
+    attribute :foo, :string
+
+    urlencoded do
       map 'bar', to: :foo
       group from: :method_from, to: :method_to do
         map 'baz'
@@ -175,6 +194,9 @@ module ShaleMapperTesting
     json do
     end
 
+    urlencoded do
+    end
+
     yaml do
     end
 
@@ -193,6 +215,9 @@ module ShaleMapperTesting
     end
 
     json do
+    end
+
+    urlencoded do
     end
 
     yaml do
@@ -292,6 +317,39 @@ RSpec.describe Shale::Mapper do
       expect(mapping['child2_foo'].attribute).to eq(:child2_foo)
 
       mapping = ShaleMapperTesting::Child3.hash_mapping.keys
+      expect(mapping.keys).to eq(%w[foo bar baz foo_int child2_foo child3_bar])
+      expect(mapping['foo'].attribute).to eq(:foo)
+      expect(mapping['bar'].attribute).to eq(:bar)
+      expect(mapping['baz'].attribute).to eq(:baz)
+      expect(mapping['foo_int'].attribute).to eq(:foo_int)
+      expect(mapping['child2_foo'].attribute).to eq(:child2_foo)
+      expect(mapping['child3_bar'].attribute).to eq(:child3_foo)
+    end
+
+    it 'copies urlencoded_mapping from parent' do
+      mapping = ShaleMapperTesting::Parent.urlencoded_mapping.keys
+      expect(mapping.keys).to eq(%w[foo bar baz foo_int])
+      expect(mapping['foo'].attribute).to eq(:foo)
+      expect(mapping['bar'].attribute).to eq(:bar)
+      expect(mapping['baz'].attribute).to eq(:baz)
+      expect(mapping['foo_int'].attribute).to eq(:foo_int)
+
+      mapping = ShaleMapperTesting::Child1.urlencoded_mapping.keys
+      expect(mapping.keys).to eq(%w[foo bar baz foo_int])
+      expect(mapping['foo'].attribute).to eq(:foo)
+      expect(mapping['bar'].attribute).to eq(:bar)
+      expect(mapping['baz'].attribute).to eq(:baz)
+      expect(mapping['foo_int'].attribute).to eq(:foo_int)
+
+      mapping = ShaleMapperTesting::Child2.urlencoded_mapping.keys
+      expect(mapping.keys).to eq(%w[foo bar baz foo_int child2_foo])
+      expect(mapping['foo'].attribute).to eq(:foo)
+      expect(mapping['bar'].attribute).to eq(:bar)
+      expect(mapping['baz'].attribute).to eq(:baz)
+      expect(mapping['foo_int'].attribute).to eq(:foo_int)
+      expect(mapping['child2_foo'].attribute).to eq(:child2_foo)
+
+      mapping = ShaleMapperTesting::Child3.urlencoded_mapping.keys
       expect(mapping.keys).to eq(%w[foo bar baz foo_int child2_foo child3_bar])
       expect(mapping['foo'].attribute).to eq(:foo)
       expect(mapping['bar'].attribute).to eq(:bar)
@@ -582,6 +640,15 @@ RSpec.describe Shale::Mapper do
         expect(mapping['foo_int'].attribute).to eq(:foo_int)
       end
 
+      it 'default urlencoded mapping' do
+        mapping = ShaleMapperTesting::Parent.urlencoded_mapping.keys
+        expect(mapping.keys).to eq(%w[foo bar baz foo_int])
+        expect(mapping['foo'].attribute).to eq(:foo)
+        expect(mapping['bar'].attribute).to eq(:bar)
+        expect(mapping['baz'].attribute).to eq(:baz)
+        expect(mapping['foo_int'].attribute).to eq(:foo_int)
+      end
+
       it 'default json mapping' do
         mapping = ShaleMapperTesting::Parent.json_mapping.keys
         expect(mapping.keys).to eq(%w[foo bar baz foo_int])
@@ -638,6 +705,28 @@ RSpec.describe Shale::Mapper do
   describe '.hsh' do
     it 'declares custom Hash mapping' do
       mapping = ShaleMapperTesting::HashMapping.hash_mapping.keys
+
+      expect(mapping.keys).to eq(%w[bar baz qux])
+      expect(mapping['bar'].attribute).to eq(:foo)
+      expect(mapping['bar'].method_from).to eq(nil)
+      expect(mapping['bar'].method_to).to eq(nil)
+      expect(mapping['bar'].group).to eq(nil)
+
+      expect(mapping['baz'].attribute).to eq(nil)
+      expect(mapping['baz'].method_from).to eq(:method_from)
+      expect(mapping['baz'].method_to).to eq(:method_to)
+      expect(mapping['baz'].group).to match('group_')
+
+      expect(mapping['qux'].attribute).to eq(nil)
+      expect(mapping['qux'].method_from).to eq(:method_from)
+      expect(mapping['qux'].method_to).to eq(:method_to)
+      expect(mapping['qux'].group).to match('group_')
+    end
+  end
+
+  describe '.urlencoded' do
+    it 'declares custom urlencoded mapping' do
+      mapping = ShaleMapperTesting::UrlencodedMapping.urlencoded_mapping.keys
 
       expect(mapping.keys).to eq(%w[bar baz qux])
       expect(mapping['bar'].attribute).to eq(:foo)
@@ -825,6 +914,7 @@ RSpec.describe Shale::Mapper do
   context 'finalized mapping' do
     it 'finalizes maping' do
       expect(ShaleMapperTesting::FinalizedParent1.hash_mapping.keys.keys).to eq([])
+      expect(ShaleMapperTesting::FinalizedParent1.urlencoded_mapping.keys.keys).to eq([])
       expect(ShaleMapperTesting::FinalizedParent1.json_mapping.keys.keys).to eq([])
       expect(ShaleMapperTesting::FinalizedParent1.yaml_mapping.keys.keys).to eq([])
       expect(ShaleMapperTesting::FinalizedParent1.toml_mapping.keys.keys).to eq([])
@@ -832,6 +922,7 @@ RSpec.describe Shale::Mapper do
       expect(ShaleMapperTesting::FinalizedParent1.xml_mapping.elements.keys).to eq([])
 
       expect(ShaleMapperTesting::FinalizedParent2.hash_mapping.keys.keys).to eq([])
+      expect(ShaleMapperTesting::FinalizedParent2.urlencoded_mapping.keys.keys).to eq([])
       expect(ShaleMapperTesting::FinalizedParent2.json_mapping.keys.keys).to eq([])
       expect(ShaleMapperTesting::FinalizedParent2.yaml_mapping.keys.keys).to eq([])
       expect(ShaleMapperTesting::FinalizedParent2.toml_mapping.keys.keys).to eq([])
@@ -839,6 +930,7 @@ RSpec.describe Shale::Mapper do
       expect(ShaleMapperTesting::FinalizedParent2.xml_mapping.elements.keys).to eq([])
 
       expect(ShaleMapperTesting::FinalizedChild1.hash_mapping.keys.keys).to eq(['two'])
+      expect(ShaleMapperTesting::FinalizedChild1.urlencoded_mapping.keys.keys).to eq(['two'])
       expect(ShaleMapperTesting::FinalizedChild1.json_mapping.keys.keys).to eq(['two'])
       expect(ShaleMapperTesting::FinalizedChild1.yaml_mapping.keys.keys).to eq(['two'])
       expect(ShaleMapperTesting::FinalizedChild1.toml_mapping.keys.keys).to eq(['two'])
@@ -846,6 +938,7 @@ RSpec.describe Shale::Mapper do
       expect(ShaleMapperTesting::FinalizedChild1.xml_mapping.elements.keys).to eq(['two'])
 
       expect(ShaleMapperTesting::FinalizedChild2.hash_mapping.keys.keys).to eq(['two'])
+      expect(ShaleMapperTesting::FinalizedChild2.urlencoded_mapping.keys.keys).to eq(['two'])
       expect(ShaleMapperTesting::FinalizedChild2.json_mapping.keys.keys).to eq(['two'])
       expect(ShaleMapperTesting::FinalizedChild2.yaml_mapping.keys.keys).to eq(['two'])
       expect(ShaleMapperTesting::FinalizedChild2.toml_mapping.keys.keys).to eq(['two'])

--- a/spec/shale/type/complex_spec/with_custom_mapping_spec.rb
+++ b/spec/shale/type/complex_spec/with_custom_mapping_spec.rb
@@ -3,6 +3,7 @@
 require 'shale'
 require 'shale/adapter/rexml'
 require 'shale/adapter/csv'
+require 'shale/adapter/rack_url_encoded'
 require 'tomlib'
 
 module ComplexSpec__CustomMapping # rubocop:disable Naming/ClassAndModuleCamelCase
@@ -11,6 +12,11 @@ module ComplexSpec__CustomMapping # rubocop:disable Naming/ClassAndModuleCamelCa
     attribute :two, :string, collection: true
 
     hsh do
+      map 'One', to: :one
+      map 'Two', to: :two
+    end
+
+    urlencoded do
       map 'One', to: :one
       map 'Two', to: :two
     end
@@ -37,6 +43,12 @@ module ComplexSpec__CustomMapping # rubocop:disable Naming/ClassAndModuleCamelCa
     attribute :child, Child
 
     hsh do
+      map 'One', to: :one
+      map 'Two', to: :two
+      map 'Child', to: :child
+    end
+
+    urlencoded do
       map 'One', to: :one
       map 'Two', to: :two
       map 'Child', to: :child
@@ -110,6 +122,7 @@ RSpec.describe Shale::Type::Complex do
     Shale.toml_adapter = Tomlib
     Shale.csv_adapter = Shale::Adapter::CSV
     Shale.xml_adapter = Shale::Adapter::REXML
+    Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
   end
 
   let(:mapper) { ComplexSpec__CustomMapping::Parent }
@@ -173,6 +186,66 @@ RSpec.describe Shale::Type::Complex do
           )
 
           expect(mapper.to_hash([instance, instance])).to eq(hash_collection)
+        end
+      end
+    end
+
+    context 'with urlencoded mapping' do
+      let(:urlencoded) do
+        'One=foo&Two%5B%5D=foo&Two%5B%5D=bar&Two%5B%5D=baz&Child%5BOne%5D=foo&' \
+          'Child%5BTwo%5D%5B%5D=foo&Child%5BTwo%5D%5B%5D=bar&Child%5BTwo%5D%5B%5D=baz'
+      end
+
+      let(:urlencoded_collection) do
+        '%5B%5D%5BOne%5D=foo&%5B%5D%5BTwo%5D%5B%5D=foo&%5B%5D%5BTwo%5D%5B%5D=bar&' \
+          '%5B%5D%5BTwo%5D%5B%5D=baz&%5B%5D%5BChild%5D%5BOne%5D=foo&%5B%5D%5BChild%5D%5BTwo%5D%5B%5D=foo&' \
+          '%5B%5D%5BChild%5D%5BTwo%5D%5B%5D=bar&%5B%5D%5BChild%5D%5BTwo%5D%5B%5D=baz&%5B%5D%5BOne%5D=foo&' \
+          '%5B%5D%5BTwo%5D%5B%5D=foo&%5B%5D%5BTwo%5D%5B%5D=bar&%5B%5D%5BTwo%5D%5B%5D=baz&' \
+          '%5B%5D%5BChild%5D%5BOne%5D=foo&%5B%5D%5BChild%5D%5BTwo%5D%5B%5D=foo&' \
+          '%5B%5D%5BChild%5D%5BTwo%5D%5B%5D=bar&%5B%5D%5BChild%5D%5BTwo%5D%5B%5D=baz'
+      end
+
+      describe '.from_urlencoded' do
+        it 'maps urlencoded to object' do
+          instance = mapper.from_urlencoded(urlencoded)
+
+          expect(instance.one).to eq('foo')
+          expect(instance.two).to eq(%w[foo bar baz])
+          expect(instance.child.one).to eq('foo')
+          expect(instance.child.two).to eq(%w[foo bar baz])
+        end
+
+        it 'maps collection to object' do
+          instance = mapper.from_urlencoded(urlencoded_collection)
+
+          2.times do |i|
+            expect(instance[i].one).to eq('foo')
+            expect(instance[i].two).to eq(%w[foo bar baz])
+            expect(instance[i].child.one).to eq('foo')
+            expect(instance[i].child.two).to eq(%w[foo bar baz])
+          end
+        end
+      end
+
+      describe '.to_urlencoded' do
+        it 'converts objects to urlencoded' do
+          instance = mapper.new(
+            one: 'foo',
+            two: %w[foo bar baz],
+            child: child_class.new(one: 'foo', two: %w[foo bar baz])
+          )
+
+          expect(instance.to_urlencoded).to eq(urlencoded)
+        end
+
+        it 'converts array to urlencoded' do
+          instance = mapper.new(
+            one: 'foo',
+            two: %w[foo bar baz],
+            child: child_class.new(one: 'foo', two: %w[foo bar baz])
+          )
+
+          expect(mapper.to_urlencoded([instance, instance])).to eq(urlencoded_collection)
         end
       end
     end

--- a/spec/shale/type/complex_spec/with_custom_model_spec.rb
+++ b/spec/shale/type/complex_spec/with_custom_model_spec.rb
@@ -3,6 +3,7 @@
 require 'shale'
 require 'shale/adapter/rexml'
 require 'shale/adapter/csv'
+require 'shale/adapter/rack_url_encoded'
 require 'tomlib'
 
 module ComplexSpec__CustomModels # rubocop:disable Naming/ClassAndModuleCamelCase
@@ -49,6 +50,7 @@ RSpec.describe Shale::Type::Complex do
     Shale.toml_adapter = Tomlib
     Shale.csv_adapter = Shale::Adapter::CSV
     Shale.xml_adapter = Shale::Adapter::REXML
+    Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
   end
 
   context 'with custom models' do
@@ -116,6 +118,70 @@ RSpec.describe Shale::Type::Complex do
 
             result = parent_mapper.to_hash([instance, instance])
             expect(result).to eq(hash_collection)
+          end
+        end
+      end
+    end
+
+    context 'with urlencoded mapping' do
+      let(:urlencoded) do
+        'one=one&child%5Bone%5D=one'
+      end
+
+      let(:urlencoded_collection) do
+        '%5B%5D%5Bone%5D=one&%5B%5D%5Bchild%5D%5Bone%5D=one&%5B%5D%5Bone%5D=one&%5B%5D%5Bchild%5D%5Bone%5D=one'
+      end
+
+      describe '.from_urlencoded' do
+        it 'maps urlencoded to object' do
+          instance = parent_mapper.from_urlencoded(urlencoded)
+
+          expect(instance.class).to eq(parent_model_class)
+          expect(instance.one).to eq('one')
+          expect(instance.child.class).to eq(child_model_class)
+          expect(instance.child.one).to eq('one')
+        end
+
+        it 'maps collection to array' do
+          instance = parent_mapper.from_urlencoded(urlencoded_collection)
+          2.times do |i|
+            expect(instance[i].class).to eq(parent_model_class)
+            expect(instance[i].one).to eq('one')
+            expect(instance[i].child.class).to eq(child_model_class)
+            expect(instance[i].child.one).to eq('one')
+          end
+        end
+      end
+
+      describe '.to_urlencoded' do
+        context 'with wrong model' do
+          it 'raises an exception' do
+            msg = /argument is a 'String' but should be a '#{parent_model_class.name}/
+
+            expect do
+              parent_mapper.to_urlencoded('')
+            end.to raise_error(Shale::IncorrectModelError, msg)
+          end
+        end
+
+        context 'with correct model' do
+          it 'converts objects to json' do
+            instance = parent_model_class.new(
+              one: 'one',
+              child: child_model_class.new(one: 'one')
+            )
+
+            expect(parent_mapper.to_urlencoded(instance)).to eq(urlencoded)
+          end
+
+          it 'converts objects to array' do
+            instance = parent_model_class.new(
+              one: 'one',
+              child: child_model_class.new(one: 'one')
+            )
+
+            result = parent_mapper.to_urlencoded([instance, instance])
+            expect(result).to eq(urlencoded_collection)
           end
         end
       end

--- a/spec/shale/type/complex_spec/with_default_mapping_spec.rb
+++ b/spec/shale/type/complex_spec/with_default_mapping_spec.rb
@@ -3,6 +3,7 @@
 require 'shale'
 require 'shale/adapter/rexml'
 require 'shale/adapter/csv'
+require 'shale/adapter/rack_url_encoded'
 require 'shale/adapter/tomlib'
 
 module ComplexSpec__DefaultMapping # rubocop:disable Naming/ClassAndModuleCamelCase
@@ -30,6 +31,7 @@ RSpec.describe Shale::Type::Complex do
     Shale.toml_adapter = Shale::Adapter::Tomlib
     Shale.csv_adapter = Shale::Adapter::CSV
     Shale.xml_adapter = Shale::Adapter::REXML
+    Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
   end
 
   let(:mapper) { ComplexSpec__DefaultMapping::Parent }
@@ -93,6 +95,69 @@ RSpec.describe Shale::Type::Complex do
           )
 
           expect(mapper.to_hash([instance, instance])).to eq(hash_collection)
+        end
+      end
+    end
+
+    context 'with urlencoded mapping' do
+      let(:urlencoded) do
+        'one=foo&two%5B%5D=foo&two%5B%5D=bar&two%5B%5D=baz&child%5Bone%5D=foo&' \
+          'child%5Btwo%5D%5B%5D=foo&child%5Btwo%5D%5B%5D=bar&child%5Btwo%5D%5B%5D=baz'
+      end
+
+      let(:urlencoded_collection) do
+        '%5B%5D%5Bone%5D=foo&%5B%5D%5Btwo%5D%5B%5D=foo&%5B%5D%5Btwo%5D%5B%5D=bar&' \
+          '%5B%5D%5Btwo%5D%5B%5D=baz&%5B%5D%5Bchild%5D%5Bone%5D=foo&%5B%5D%5Bchild%5D%5Btwo%5D%5B%5D=foo&' \
+          '%5B%5D%5Bchild%5D%5Btwo%5D%5B%5D=bar&%5B%5D%5Bchild%5D%5Btwo%5D%5B%5D=baz&' \
+          '%5B%5D%5Bone%5D=foo&%5B%5D%5Btwo%5D%5B%5D=foo&%5B%5D%5Btwo%5D%5B%5D=bar&' \
+          '%5B%5D%5Btwo%5D%5B%5D=baz&%5B%5D%5Bchild%5D%5Bone%5D=foo&' \
+          '%5B%5D%5Bchild%5D%5Btwo%5D%5B%5D=foo&%5B%5D%5Bchild%5D%5Btwo%5D%5B%5D=bar&' \
+          '%5B%5D%5Bchild%5D%5Btwo%5D%5B%5D=baz'
+      end
+
+      describe '.from_urlencoded' do
+        it 'maps urlencoded to object' do
+          instance = mapper.from_urlencoded(urlencoded)
+
+          expect(instance.one).to eq('foo')
+          expect(instance.two).to eq(%w[foo bar baz])
+          expect(instance.child.one).to eq('foo')
+          expect(instance.child.two).to eq(%w[foo bar baz])
+        end
+
+        it 'maps collection to object' do
+          instance = mapper.from_urlencoded(urlencoded_collection)
+
+          2.times do |i|
+            expect(instance[i].one).to eq('foo')
+            expect(instance[i].two).to eq(%w[foo bar baz])
+            expect(instance[i].child.one).to eq('foo')
+            expect(instance[i].child.two).to eq(%w[foo bar baz])
+          end
+        end
+      end
+
+      describe '.to_urlencoded' do
+        context 'without params' do
+          it 'converts objects to urlencoded' do
+            instance = mapper.new(
+              one: 'foo',
+              two: %w[foo bar baz],
+              child: child_class.new(one: 'foo', two: %w[foo bar baz])
+            )
+
+            expect(instance.to_urlencoded).to eq(urlencoded)
+          end
+
+          it 'converts array to urlencoded' do
+            instance = mapper.new(
+              one: 'foo',
+              two: %w[foo bar baz],
+              child: child_class.new(one: 'foo', two: %w[foo bar baz])
+            )
+
+            expect(mapper.to_urlencoded([instance, instance])).to eq(urlencoded_collection)
+          end
         end
       end
     end

--- a/spec/shale/type/complex_spec/with_delegation_spec.rb
+++ b/spec/shale/type/complex_spec/with_delegation_spec.rb
@@ -433,7 +433,8 @@ RSpec.describe Shale::Type::Complex do
           let(:parent) { ComplexSpec__Delegation::ParentNoChild }
 
           let(:urlencoded) do
-            '%5B%5D%5Bone%5D=one&%5B%5D%5Btwo%5D=two&%5B%5D%5Bthree%5D=three&%5B%5D%5Bone%5D=one&%5B%5D%5Btwo%5D=two&%5B%5D%5Bthree%5D=three'
+            '%5B%5D%5Bone%5D=one&%5B%5D%5Btwo%5D=two&%5B%5D%5Bthree%5D=three&' \
+              '%5B%5D%5Bone%5D=one&%5B%5D%5Btwo%5D=two&%5B%5D%5Bthree%5D=three'
           end
 
           it 'maps collection to array' do

--- a/spec/shale/type/complex_spec/with_delegation_spec.rb
+++ b/spec/shale/type/complex_spec/with_delegation_spec.rb
@@ -3,6 +3,7 @@
 require 'shale'
 require 'shale/adapter/rexml'
 require 'shale/adapter/csv'
+require 'shale/adapter/rack_url_encoded'
 require 'tomlib'
 
 module ComplexSpec__Delegation # rubocop:disable Naming/ClassAndModuleCamelCase
@@ -16,6 +17,12 @@ module ComplexSpec__Delegation # rubocop:disable Naming/ClassAndModuleCamelCase
     attribute :child, Child
 
     hsh do
+      map 'one', to: :one
+      map 'two', to: :two, receiver: :child
+      map 'three', to: :three, receiver: :child
+    end
+
+    urlencoded do
       map 'one', to: :one
       map 'two', to: :two, receiver: :child
       map 'three', to: :three, receiver: :child
@@ -82,6 +89,13 @@ module ComplexSpec__Delegation # rubocop:disable Naming/ClassAndModuleCamelCase
     attribute :child, Child
 
     hsh do
+      map 'one', to: :one
+      map 'two', to: :two, receiver: :child
+      map 'three', to: :three, receiver: :child
+      map 'child', to: :child
+    end
+
+    urlencoded do
       map 'one', to: :one
       map 'two', to: :two, receiver: :child
       map 'three', to: :three, receiver: :child
@@ -168,6 +182,7 @@ RSpec.describe Shale::Type::Complex do
     Shale.toml_adapter = Tomlib
     Shale.csv_adapter = Shale::Adapter::CSV
     Shale.xml_adapter = Shale::Adapter::REXML
+    Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
   end
 
   context 'with delegation' do
@@ -360,6 +375,109 @@ RSpec.describe Shale::Type::Complex do
 
           result = parent.to_hash([instance, instance])
           expect(result).to eq(hash_collection)
+        end
+      end
+    end
+
+    context 'with urlencoded mapping' do
+      describe '.from_urlencoded' do
+        context 'with no child mapping' do
+          let(:parent) { ComplexSpec__Delegation::ParentNoChild }
+
+          let(:urlencoded) do
+            'one=one&two=two&three=three'
+          end
+
+          it 'maps urlencoded to object' do
+            instance = parent.from_urlencoded(urlencoded)
+
+            expect(instance.one).to eq('one')
+            expect(instance.child.two).to eq('two')
+            expect(instance.child.three).to eq('three')
+          end
+        end
+
+        context 'with child mapping before delegates' do
+          let(:parent) { ComplexSpec__Delegation::ParentChild }
+
+          let(:urlencoded) do
+            'one=one&child%5Btwo%5D=foo&child%5Bthree%5D=bar&two=two'
+          end
+
+          it 'maps urlencoded to object' do
+            instance = parent.from_urlencoded(urlencoded)
+
+            expect(instance.one).to eq('one')
+            expect(instance.child.two).to eq('two')
+            expect(instance.child.three).to eq('bar')
+          end
+        end
+
+        context 'with child mapping after delegates' do
+          let(:parent) { ComplexSpec__Delegation::ParentChild }
+
+          let(:urlencoded) do
+            'one=one&two=two&child%5Btwo%5D=foo&child%5Bthree%5D=bar'
+          end
+
+          it 'maps urlencoded to object' do
+            instance = parent.from_urlencoded(urlencoded)
+
+            expect(instance.one).to eq('one')
+            expect(instance.child.two).to eq('two')
+            expect(instance.child.three).to eq('bar')
+          end
+        end
+
+        context 'with collection' do
+          let(:parent) { ComplexSpec__Delegation::ParentNoChild }
+
+          let(:urlencoded) do
+            '%5B%5D%5Bone%5D=one&%5B%5D%5Btwo%5D=two&%5B%5D%5Bthree%5D=three&%5B%5D%5Bone%5D=one&%5B%5D%5Btwo%5D=two&%5B%5D%5Bthree%5D=three'
+          end
+
+          it 'maps collection to array' do
+            instance = parent.from_urlencoded(urlencoded)
+
+            2.times do |i|
+              expect(instance[i].one).to eq('one')
+              expect(instance[i].child.two).to eq('two')
+              expect(instance[i].child.three).to eq('three')
+            end
+          end
+        end
+      end
+
+      describe '.to_urlencoded' do
+        let(:parent) { ComplexSpec__Delegation::ParentNoChild }
+        let(:child) { ComplexSpec__Delegation::Child }
+
+        let(:urlencoded) do
+          'one=one&two=two&three=three'
+        end
+
+        let(:urlencoded_collection) do
+          '%5B%5D%5Bone%5D=one&%5B%5D%5Btwo%5D=two&%5B%5D%5Bthree%5D=three&' \
+            '%5B%5D%5Bone%5D=one&%5B%5D%5Btwo%5D=two&%5B%5D%5Bthree%5D=three'
+        end
+
+        it 'converts objects to urlencoded' do
+          instance = parent.new(
+            one: 'one',
+            child: child.new(two: 'two', three: 'three')
+          )
+
+          expect(parent.to_urlencoded(instance)).to eq(urlencoded)
+        end
+
+        it 'converts objects to array' do
+          instance = parent.new(
+            one: 'one',
+            child: child.new(two: 'two', three: 'three')
+          )
+
+          result = parent.to_urlencoded([instance, instance])
+          expect(result).to eq(urlencoded_collection)
         end
       end
     end

--- a/spec/shale/type/complex_spec/with_only_except_options_spec.rb
+++ b/spec/shale/type/complex_spec/with_only_except_options_spec.rb
@@ -3,6 +3,7 @@
 require 'shale'
 require 'shale/adapter/rexml'
 require 'shale/adapter/csv'
+require 'shale/adapter/rack_url_encoded'
 require 'tomlib'
 
 module ComplexSpec__OnlyExceptOptions # rubocop:disable Naming/ClassAndModuleCamelCase
@@ -80,6 +81,7 @@ RSpec.describe Shale::Type::Complex do
     Shale.toml_adapter = Tomlib
     Shale.csv_adapter = Shale::Adapter::CSV
     Shale.xml_adapter = Shale::Adapter::REXML
+    Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
   end
 
   context 'with only/except options' do
@@ -362,6 +364,212 @@ RSpec.describe Shale::Type::Complex do
               },
             ]
           )
+        end
+      end
+    end
+
+    context 'with urlencoded mapping' do
+      let(:urlencoded) do
+        'first_name=John&last_name=Doe&age=44&hobby%5B%5D=Singing&hobby%5B%5D=Dancing&address%5Bcity%5D=London&' \
+          'address%5Bzip%5D=1N+ASD123&address%5Bstreet%5D%5Bname%5D=Oxford+Street&address%5Bstreet%5D%5Bhouse_no%5D=1&' \
+          'address%5Bstreet%5D%5Bflat_no%5D=2&car%5B%5D%5Bbrand%5D=Honda&car%5B%5D%5Bmodel%5D=Accord&' \
+          'car%5B%5D%5Bengine%5D=1.4&car%5B%5D%5Bbrand%5D=Toyota&car%5B%5D%5Bmodel%5D=Corolla&car%5B%5D%5Bengine%5D=2.0'
+      end
+
+      let(:urlencoded_collection) do
+        '%5B%5D%5Bfirst_name%5D=John&%5B%5D%5Blast_name%5D=Doe&%5B%5D%5Bage%5D=44&%5B%5D%5Bhobby%5D%5B%5D=Singing&' \
+          '%5B%5D%5Bhobby%5D%5B%5D=Dancing&%5B%5D%5Baddress%5D%5Bcity%5D=London&%5B%5D%5Baddress%5D%5Bzip%5D=1N+ASD123&' \
+          '%5B%5D%5Baddress%5D%5Bstreet%5D%5Bname%5D=Oxford+Street&%5B%5D%5Baddress%5D%5Bstreet%5D%5Bhouse_no%5D=1&' \
+          '%5B%5D%5Baddress%5D%5Bstreet%5D%5Bflat_no%5D=2&%5B%5D%5Bcar%5D%5B%5D%5Bbrand%5D=Honda&' \
+          '%5B%5D%5Bcar%5D%5B%5D%5Bmodel%5D=Accord&%5B%5D%5Bcar%5D%5B%5D%5Bengine%5D=1.4&' \
+          '%5B%5D%5Bcar%5D%5B%5D%5Bbrand%5D=Toyota&%5B%5D%5Bcar%5D%5B%5D%5Bmodel%5D=Corolla&' \
+          '%5B%5D%5Bcar%5D%5B%5D%5Bengine%5D=2.0&%5B%5D%5Bfirst_name%5D=John&%5B%5D%5Blast_name%5D=Doe&' \
+          '%5B%5D%5Bage%5D=44&%5B%5D%5Bhobby%5D%5B%5D=Singing&%5B%5D%5Bhobby%5D%5B%5D=Dancing&' \
+          '%5B%5D%5Baddress%5D%5Bcity%5D=London&%5B%5D%5Baddress%5D%5Bzip%5D=1N+ASD123&' \
+          '%5B%5D%5Baddress%5D%5Bstreet%5D%5Bname%5D=Oxford+Street&%5B%5D%5Baddress%5D%5Bstreet%5D%5Bhouse_no%5D=1&' \
+          '%5B%5D%5Baddress%5D%5Bstreet%5D%5Bflat_no%5D=2&%5B%5D%5Bcar%5D%5B%5D%5Bbrand%5D=Honda&' \
+          '%5B%5D%5Bcar%5D%5B%5D%5Bmodel%5D=Accord&%5B%5D%5Bcar%5D%5B%5D%5Bengine%5D=1.4&' \
+          '%5B%5D%5Bcar%5D%5B%5D%5Bbrand%5D=Toyota&%5B%5D%5Bcar%5D%5B%5D%5Bmodel%5D=Corolla&' \
+          '%5B%5D%5Bcar%5D%5B%5D%5Bengine%5D=2.0'
+      end
+
+      describe '.from_urlencoded' do
+        it 'maps urlencoded to partial object' do
+          instance = mapper.from_urlencoded(
+            urlencoded,
+            only: [
+              :first_name,
+              { address: [:zip, { street: [:flat_no] }] },
+              { car: [:model] },
+            ]
+          )
+          expect(instance.first_name).to eq('John')
+          expect(instance.last_name).to eq(nil)
+          expect(instance.age).to eq(nil)
+          expect(instance.address.city).to eq(nil)
+          expect(instance.address.zip).to eq('1N ASD123')
+          expect(instance.address.street.name).to eq(nil)
+          expect(instance.address.street.house_no).to eq(nil)
+          expect(instance.address.street.flat_no).to eq('2')
+          expect(instance.car[0].brand).to eq(nil)
+          expect(instance.car[0].model).to eq('Accord')
+          expect(instance.car[0].engine).to eq(nil)
+          expect(instance.car[1].brand).to eq(nil)
+          expect(instance.car[1].model).to eq('Corolla')
+          expect(instance.car[1].engine).to eq(nil)
+
+          instance = mapper.from_urlencoded(
+            urlencoded,
+            except: [
+              :first_name,
+              { address: [:zip, { street: [:flat_no] }] },
+              { car: [:model] },
+            ]
+          )
+          expect(instance.first_name).to eq(nil)
+          expect(instance.last_name).to eq('Doe')
+          expect(instance.age).to eq(44)
+          expect(instance.address.city).to eq('London')
+          expect(instance.address.zip).to eq(nil)
+          expect(instance.address.street.name).to eq('Oxford Street')
+          expect(instance.address.street.house_no).to eq('1')
+          expect(instance.address.street.flat_no).to eq(nil)
+          expect(instance.car[0].brand).to eq('Honda')
+          expect(instance.car[0].model).to eq(nil)
+          expect(instance.car[0].engine).to eq('1.4')
+          expect(instance.car[1].brand).to eq('Toyota')
+          expect(instance.car[1].model).to eq(nil)
+          expect(instance.car[1].engine).to eq('2.0')
+        end
+
+        it 'maps urlencoded collection to partial object' do
+          instance = mapper.from_urlencoded(
+            urlencoded_collection,
+            only: [
+              :first_name,
+              { address: [:zip, { street: [:flat_no] }] },
+              { car: [:model] },
+            ]
+          )
+          2.times do |i|
+            expect(instance[i].first_name).to eq('John')
+            expect(instance[i].last_name).to eq(nil)
+            expect(instance[i].age).to eq(nil)
+            expect(instance[i].address.city).to eq(nil)
+            expect(instance[i].address.zip).to eq('1N ASD123')
+            expect(instance[i].address.street.name).to eq(nil)
+            expect(instance[i].address.street.house_no).to eq(nil)
+            expect(instance[i].address.street.flat_no).to eq('2')
+            expect(instance[i].car[0].brand).to eq(nil)
+            expect(instance[i].car[0].model).to eq('Accord')
+            expect(instance[i].car[0].engine).to eq(nil)
+            expect(instance[i].car[1].brand).to eq(nil)
+            expect(instance[i].car[1].model).to eq('Corolla')
+            expect(instance[i].car[1].engine).to eq(nil)
+          end
+
+          instance = mapper.from_urlencoded(
+            urlencoded_collection,
+            except: [
+              :first_name,
+              { address: [:zip, { street: [:flat_no] }] },
+              { car: [:model] },
+            ]
+          )
+          2.times do |i|
+            expect(instance[i].first_name).to eq(nil)
+            expect(instance[i].last_name).to eq('Doe')
+            expect(instance[i].age).to eq(44)
+            expect(instance[i].address.city).to eq('London')
+            expect(instance[i].address.zip).to eq(nil)
+            expect(instance[i].address.street.name).to eq('Oxford Street')
+            expect(instance[i].address.street.house_no).to eq('1')
+            expect(instance[i].address.street.flat_no).to eq(nil)
+            expect(instance[i].car[0].brand).to eq('Honda')
+            expect(instance[i].car[0].model).to eq(nil)
+            expect(instance[i].car[0].engine).to eq('1.4')
+            expect(instance[i].car[1].brand).to eq('Toyota')
+            expect(instance[i].car[1].model).to eq(nil)
+            expect(instance[i].car[1].engine).to eq('2.0')
+          end
+        end
+      end
+
+      describe '.to_urlencoded' do
+        it 'converts objects to partial urlencoded' do
+          instance = mapper.from_urlencoded(urlencoded)
+
+          result = instance.to_urlencoded(
+            only: [
+              :first_name,
+              { address: [:zip, { street: [:flat_no] }] },
+              { car: [:model] },
+            ],
+            pretty: true
+          )
+          expected =
+            'first_name=John&address%5Bzip%5D=1N+ASD123&address%5Bstreet%5D%5Bflat_no%5D=2&' \
+            'car%5B%5D%5Bmodel%5D=Accord&car%5B%5D%5Bmodel%5D=Corolla'
+
+          expect(result).to eq(expected)
+
+          result = instance.to_urlencoded(
+            except: [
+              :first_name,
+              { address: [:zip, { street: [:flat_no] }] },
+              { car: [:model] },
+            ],
+            pretty: true
+          )
+          expected =
+            'last_name=Doe&age=44&address%5Bcity%5D=London&address%5Bstreet%5D%5Bname%5D=Oxford+Street&' \
+            'address%5Bstreet%5D%5Bhouse_no%5D=1&car%5B%5D%5Bbrand%5D=Honda&car%5B%5D%5Bengine%5D=1.4&' \
+            'car%5B%5D%5Bbrand%5D=Toyota&car%5B%5D%5Bengine%5D=2.0'
+
+          expect(result).to eq(expected)
+        end
+
+        it 'converts array to partial urlencoded' do
+          instance = mapper.from_urlencoded(urlencoded_collection)
+
+          result = mapper.to_urlencoded(
+            instance,
+            only: [
+              :first_name,
+              { address: [:zip, { street: [:flat_no] }] },
+              { car: [:model] },
+            ],
+            pretty: true
+          )
+          expected =
+            '%5B%5D%5Bfirst_name%5D=John&%5B%5D%5Baddress%5D%5Bzip%5D=1N+ASD123&' \
+            '%5B%5D%5Baddress%5D%5Bstreet%5D%5Bflat_no%5D=2&%5B%5D%5Bcar%5D%5B%5D%5Bmodel%5D=Accord&' \
+            '%5B%5D%5Bcar%5D%5B%5D%5Bmodel%5D=Corolla&%5B%5D%5Bfirst_name%5D=John&' \
+            '%5B%5D%5Baddress%5D%5Bzip%5D=1N+ASD123&%5B%5D%5Baddress%5D%5Bstreet%5D%5Bflat_no%5D=2&' \
+            '%5B%5D%5Bcar%5D%5B%5D%5Bmodel%5D=Accord&%5B%5D%5Bcar%5D%5B%5D%5Bmodel%5D=Corolla'
+
+          expect(result).to eq(expected)
+
+          result = mapper.to_urlencoded(
+            instance,
+            except: [
+              :first_name,
+              { address: [:zip, { street: [:flat_no] }] },
+              { car: [:model] },
+            ],
+            pretty: true
+          )
+          expected =
+            '%5B%5D%5Blast_name%5D=Doe&%5B%5D%5Bage%5D=44&%5B%5D%5Baddress%5D%5Bcity%5D=London&' \
+            '%5B%5D%5Baddress%5D%5Bstreet%5D%5Bname%5D=Oxford+Street&' \
+            '%5B%5D%5Baddress%5D%5Bstreet%5D%5Bhouse_no%5D=1&%5B%5D%5Bcar%5D%5B%5D%5Bbrand%5D=Honda&' \
+            '%5B%5D%5Bcar%5D%5B%5D%5Bengine%5D=1.4&%5B%5D%5Bcar%5D%5B%5D%5Bbrand%5D=Toyota&' \
+            '%5B%5D%5Bcar%5D%5B%5D%5Bengine%5D=2.0&%5B%5D%5Blast_name%5D=Doe&%5B%5D%5Bage%5D=44&' \
+            '%5B%5D%5Baddress%5D%5Bcity%5D=London&%5B%5D%5Baddress%5D%5Bstreet%5D%5Bname%5D=Oxford+Street&' \
+            '%5B%5D%5Baddress%5D%5Bstreet%5D%5Bhouse_no%5D=1&%5B%5D%5Bcar%5D%5B%5D%5Bbrand%5D=Honda&' \
+            '%5B%5D%5Bcar%5D%5B%5D%5Bengine%5D=1.4&%5B%5D%5Bcar%5D%5B%5D%5Bbrand%5D=Toyota&' \
+            '%5B%5D%5Bcar%5D%5B%5D%5Bengine%5D=2.0'
+          expect(result).to eq(expected)
         end
       end
     end

--- a/spec/shale/type/complex_spec/with_render_nil_default_spec.rb
+++ b/spec/shale/type/complex_spec/with_render_nil_default_spec.rb
@@ -3,6 +3,7 @@
 require 'shale'
 require 'shale/adapter/rexml'
 require 'shale/adapter/csv'
+require 'shale/adapter/rack_url_encoded'
 require 'tomlib'
 
 module ComplexSpec__RenderNilDefault # rubocop:disable Naming/ClassAndModuleCamelCase
@@ -10,6 +11,11 @@ module ComplexSpec__RenderNilDefault # rubocop:disable Naming/ClassAndModuleCame
     attribute :base, Shale::Type::String
 
     hsh do
+      render_nil true
+      map 'base', to: :base
+    end
+
+    urlencoded do
       render_nil true
       map 'base', to: :base
     end
@@ -40,6 +46,11 @@ module ComplexSpec__RenderNilDefault # rubocop:disable Naming/ClassAndModuleCame
     attribute :bar, Shale::Type::String
 
     hsh do
+      map 'foo', to: :foo
+      map 'bar', to: :bar
+    end
+
+    urlencoded do
       map 'foo', to: :foo
       map 'bar', to: :bar
     end
@@ -75,6 +86,12 @@ module ComplexSpec__RenderNilDefault # rubocop:disable Naming/ClassAndModuleCame
       map 'bar', to: :bar
     end
 
+    urlencoded do
+      render_nil false
+      map 'foo', to: :foo
+      map 'bar', to: :bar
+    end
+
     json do
       render_nil false
       map 'foo', to: :foo
@@ -105,6 +122,11 @@ module ComplexSpec__RenderNilDefault # rubocop:disable Naming/ClassAndModuleCame
     attribute :bar, Shale::Type::String
 
     hsh do
+      map 'foo', to: :foo
+      map 'bar', to: :bar, render_nil: false
+    end
+
+    urlencoded do
       map 'foo', to: :foo
       map 'bar', to: :bar, render_nil: false
     end
@@ -200,6 +222,7 @@ RSpec.describe Shale::Type::Complex do
     Shale.toml_adapter = Tomlib
     Shale.csv_adapter = Shale::Adapter::CSV
     Shale.xml_adapter = Shale::Adapter::REXML
+    Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
   end
 
   context 'with render_nil default' do
@@ -209,6 +232,13 @@ RSpec.describe Shale::Type::Complex do
       it 'converts objects to format' do
         instance = mapper.new(foo: 'foo')
         expect(instance.to_hash).to eq({ 'base' => nil, 'foo' => 'foo', 'bar' => nil })
+      end
+    end
+
+    describe '.to_urlencoded' do
+      it 'converts objects to format' do
+        instance = mapper.new(foo: 'foo')
+        expect(instance.to_urlencoded).to eq('base&foo=foo&bar')
       end
     end
 
@@ -262,6 +292,13 @@ RSpec.describe Shale::Type::Complex do
       it 'converts objects to format' do
         instance = mapper.new(foo: 'foo')
         expect(instance.to_hash).to eq({ 'base' => nil, 'foo' => 'foo' })
+      end
+    end
+
+    describe '.to_urlencoded' do
+      it 'converts objects to format' do
+        instance = mapper.new(foo: 'foo')
+        expect(instance.to_urlencoded).to eq('base&foo=foo')
       end
     end
 
@@ -321,6 +358,13 @@ RSpec.describe Shale::Type::Complex do
       it 'converts objects to format' do
         instance = mapper.new(foo: 'foo')
         expect(instance.to_json).to eq('{"base":null,"foo":"foo"}')
+      end
+    end
+
+    describe '.to_urlencoded' do
+      it 'converts objects to format' do
+        instance = mapper.new(foo: 'foo')
+        expect(instance.to_urlencoded).to eq('base&foo=foo')
       end
     end
 

--- a/spec/shale/type/complex_spec/with_render_nil_spec.rb
+++ b/spec/shale/type/complex_spec/with_render_nil_spec.rb
@@ -3,6 +3,7 @@
 require 'shale'
 require 'shale/adapter/rexml'
 require 'shale/adapter/csv'
+require 'shale/adapter/rack_url_encoded'
 require 'tomlib'
 
 module ComplexSpec__RenderNil # rubocop:disable Naming/ClassAndModuleCamelCase
@@ -11,6 +12,11 @@ module ComplexSpec__RenderNil # rubocop:disable Naming/ClassAndModuleCamelCase
     attribute :attr_false, Shale::Type::String
 
     hsh do
+      map 'attr_true', to: :attr_true, render_nil: true
+      map 'attr_false', to: :attr_false, render_nil: false
+    end
+
+    urlencoded do
       map 'attr_true', to: :attr_true, render_nil: true
       map 'attr_false', to: :attr_false, render_nil: false
     end
@@ -77,6 +83,7 @@ RSpec.describe Shale::Type::Complex do
     Shale.toml_adapter = Tomlib
     Shale.csv_adapter = Shale::Adapter::CSV
     Shale.xml_adapter = Shale::Adapter::REXML
+    Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
   end
 
   let(:mapper) { ComplexSpec__RenderNil::RenderNilDict }
@@ -99,6 +106,24 @@ RSpec.describe Shale::Type::Complex do
           { 'attr_true' => nil },
           { 'attr_true' => 'foo', 'attr_false' => 'bar' },
         ])
+      end
+    end
+
+    describe '.to_urlencoded' do
+      it 'converts objects to urlencoded' do
+        instance1 = mapper.new(attr_true: nil, attr_false: nil)
+        instance2 = mapper.new(attr_true: 'foo', attr_false: 'bar')
+
+        expect(instance1.to_urlencoded).to eq('attr_true')
+        expect(instance2.to_urlencoded).to eq('attr_true=foo&attr_false=bar')
+      end
+
+      it 'converts collection to urlencoded' do
+        instance1 = mapper.new(attr_true: nil, attr_false: nil)
+        instance2 = mapper.new(attr_true: 'foo', attr_false: 'bar')
+
+        result = mapper.to_urlencoded([instance1, instance2])
+        expect(result).to eq('%5B%5D%5Battr_true%5D&%5B%5D%5Battr_true%5D=foo&%5B%5D%5Battr_false%5D=bar')
       end
     end
 

--- a/spec/shale/type/complex_spec/with_types_spec.rb
+++ b/spec/shale/type/complex_spec/with_types_spec.rb
@@ -3,6 +3,7 @@
 require 'shale'
 require 'shale/adapter/rexml'
 require 'shale/adapter/csv'
+require 'shale/adapter/rack_url_encoded'
 require 'tomlib'
 
 module ComplexSpec__Types # rubocop:disable Naming/ClassAndModuleCamelCase
@@ -58,6 +59,7 @@ RSpec.describe Shale::Type::Complex do
     Shale.toml_adapter = Tomlib
     Shale.csv_adapter = Shale::Adapter::CSV
     Shale.xml_adapter = Shale::Adapter::REXML
+    Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
   end
 
   let(:mapper) { ComplexSpec__Types::Root }
@@ -193,6 +195,51 @@ RSpec.describe Shale::Type::Complex do
         it 'converts objects to hash' do
           result = instance.to_hash
           expect(result).to eq(hash)
+        end
+      end
+    end
+
+    context 'with urlencoded mapping' do
+      let(:urlencoded) do
+        'type_boolean=true&type_date=2022-01-01&type_decimal=1.1&type_float=1.1&type_integer=1&type_string=foo&' \
+          'type_time=2021-01-01T10%3A10%3A10%2B01%3A00&type_value=foo&child%5Btype_boolean%5D=true&' \
+          'child%5Btype_date%5D=2022-01-01&child%5Btype_decimal%5D=1.1&child%5Btype_float%5D=1.1&' \
+          'child%5Btype_integer%5D=1&child%5Btype_string%5D=foo&' \
+          'child%5Btype_time%5D=2021-01-01T10%3A10%3A10%2B01%3A00&' \
+          'child%5Btype_value%5D=foo&type_boolean_collection%5B%5D=true&' \
+          'type_boolean_collection%5B%5D=false&type_date_collection%5B%5D=2022-01-01&' \
+          'type_date_collection%5B%5D=2022-01-02&type_decimal_collection%5B%5D=1.1&' \
+          'type_decimal_collection%5B%5D=2.2&type_float_collection%5B%5D=1.1&' \
+          'type_float_collection%5B%5D=2.2&type_integer_collection%5B%5D=1&' \
+          'type_integer_collection%5B%5D=2&type_string_collection%5B%5D=foo&' \
+          'type_string_collection%5B%5D=bar&type_time_collection%5B%5D=2021-01-01T10%3A10%3A10%2B01%3A00&' \
+          'type_time_collection%5B%5D=2021-01-02T10%3A10%3A10%2B01%3A00&type_value_collection%5B%5D=foo&' \
+          'type_value_collection%5B%5D=1&type_value_collection%5B%5D=true&' \
+          'child_collection%5B%5D%5Btype_boolean%5D=true&child_collection%5B%5D%5Btype_date%5D=2022-01-01&' \
+          'child_collection%5B%5D%5Btype_decimal%5D=1.1&child_collection%5B%5D%5Btype_float%5D=1.1&' \
+          'child_collection%5B%5D%5Btype_integer%5D=1&child_collection%5B%5D%5Btype_string%5D=foo&' \
+          'child_collection%5B%5D%5Btype_time%5D=2021-01-01T10%3A10%3A10%2B01%3A00&' \
+          'child_collection%5B%5D%5Btype_value%5D=foo&child_collection%5B%5D%5Btype_boolean%5D=true&' \
+          'child_collection%5B%5D%5Btype_date%5D=2022-01-01&child_collection%5B%5D%5Btype_decimal%5D=1.1&' \
+          'child_collection%5B%5D%5Btype_float%5D=1.1&child_collection%5B%5D%5Btype_integer%5D=1&' \
+          'child_collection%5B%5D%5Btype_string%5D=foo&' \
+          'child_collection%5B%5D%5Btype_time%5D=2021-01-01T10%3A10%3A10%2B01%3A00&' \
+          'child_collection%5B%5D%5Btype_value%5D=foo'
+      end
+      let(:instance) { mapper.from_urlencoded(urlencoded) }
+
+      describe '.from_urlencoded' do
+        include_examples 'maps to object'
+
+        it 'maps value collection to object as strings' do
+          expect(instance.type_value_collection).to eq(%w[foo 1 true])
+        end
+      end
+
+      describe '.to_urlencoded' do
+        it 'converts objects to JSON' do
+          result = instance.to_urlencoded
+          expect(result).to eq(urlencoded)
         end
       end
     end

--- a/spec/shale/type/complex_spec/with_using_block_spec.rb
+++ b/spec/shale/type/complex_spec/with_using_block_spec.rb
@@ -3,6 +3,7 @@
 require 'shale'
 require 'shale/adapter/rexml'
 require 'shale/adapter/csv'
+require 'shale/adapter/rack_url_encoded'
 require 'tomlib'
 
 module ComplexSpec__UsingBlock # rubocop:disable Naming/ClassAndModuleCamelCase
@@ -12,6 +13,13 @@ module ComplexSpec__UsingBlock # rubocop:disable Naming/ClassAndModuleCamelCase
     attribute :three, Shale::Type::String
 
     hsh do
+      group from: :attrs_from_dict, to: :attrs_to_dict do
+        map 'one'
+        map 'two'
+      end
+    end
+
+    urlencoded do
       group from: :attrs_from_dict, to: :attrs_to_dict do
         map 'one'
         map 'two'
@@ -93,6 +101,13 @@ module ComplexSpec__UsingBlock # rubocop:disable Naming/ClassAndModuleCamelCase
       end
     end
 
+    urlencoded do
+      group from: :attrs_from_dict, to: :attrs_to_dict do
+        map 'one'
+        map 'two'
+      end
+    end
+
     json do
       group from: :attrs_from_dict, to: :attrs_to_dict do
         map 'one'
@@ -164,6 +179,7 @@ RSpec.describe Shale::Type::Complex do
     Shale.toml_adapter = Tomlib
     Shale.csv_adapter = Shale::Adapter::CSV
     Shale.xml_adapter = Shale::Adapter::REXML
+    Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
   end
 
   context 'with using block' do
@@ -214,6 +230,48 @@ RSpec.describe Shale::Type::Complex do
           it 'converts array to hash' do
             instance = mapper.new(one: 'one', two: 'two')
             expect(mapper.to_hash([instance, instance])).to eq(hash_collection)
+          end
+        end
+      end
+
+      context 'with urlencoded mapping' do
+        let(:urlencoded) do
+          'one=one&two=two'
+        end
+
+        let(:urlencoded_collection) do
+          '%5B%5D%5Bone%5D=one&%5B%5D%5Btwo%5D=two&%5B%5D%5Bone%5D=one&%5B%5D%5Btwo%5D=two'
+        end
+
+        describe '.from_urlencoded' do
+          it 'maps urlencoded to object' do
+            instance = mapper.from_urlencoded(urlencoded)
+
+            expect(instance.one).to eq('one')
+            expect(instance.two).to eq('two')
+          end
+
+          it 'maps collection to urlencoded' do
+            instance = mapper.from_urlencoded(urlencoded_collection)
+
+            2.times do |i|
+              expect(instance[i].one).to eq('one')
+              expect(instance[i].two).to eq('two')
+            end
+          end
+        end
+
+        describe '.to_urlencoded' do
+          it 'converts objects to urlencoded' do
+            instance = mapper.new(one: 'one', two: 'two')
+
+            result = instance.to_urlencoded
+            expect(result).to eq(urlencoded)
+          end
+
+          it 'converts array to urlencoded' do
+            instance = mapper.new(one: 'one', two: 'two')
+            expect(mapper.to_urlencoded([instance, instance], pretty: true)).to eq(urlencoded_collection)
           end
         end
       end
@@ -482,6 +540,52 @@ RSpec.describe Shale::Type::Complex do
               { 'one' => 'one:foo', 'two' => 'two:foo' },
               { 'one' => 'one:foo', 'two' => 'two:foo' },
             ])
+          end
+        end
+      end
+
+      context 'with urlencoded mapping' do
+        let(:urlencoded) do
+          'one=one&two=two'
+        end
+
+        let(:urlencoded_collection) do
+          '%5B%5D%5Bone%5D=one&%5B%5D%5Btwo%5D=two&%5B%5D%5Bone%5D=one&%5B%5D%5Btwo%5D=two'
+        end
+
+        describe '.from_urlencoded' do
+          it 'maps urlencoded to object' do
+            instance = mapper.from_urlencoded(urlencoded, context: 'foo')
+
+            expect(instance.one).to eq('one:foo')
+            expect(instance.two).to eq('two:foo')
+          end
+
+          it 'maps collection to object' do
+            instance = mapper.from_urlencoded(urlencoded_collection, context: 'foo')
+
+            2.times do |i|
+              expect(instance[i].one).to eq('one:foo')
+              expect(instance[i].two).to eq('two:foo')
+            end
+          end
+        end
+
+        describe '.to_urlencoded' do
+          it 'converts objects to urlencoded' do
+            instance = mapper.new(one: 'one', two: 'two')
+
+            result = instance.to_urlencoded(context: 'foo')
+            expect(result).to eq('one=one%3Afoo&two=two%3Afoo')
+          end
+
+          it 'converts array to urlencoded' do
+            instance = mapper.new(one: 'one', two: 'two')
+            result = mapper.to_urlencoded([instance, instance], context: 'foo')
+            expected =
+              '%5B%5D%5Bone%5D=one%3Afoo&%5B%5D%5Btwo%5D=two%3Afoo&%5B%5D%5Bone%5D=one%3Afoo&%5B%5D%5Btwo%5D=two%3Afoo'
+
+            expect(result).to eq(expected)
           end
         end
       end

--- a/spec/shale/type/complex_spec/with_using_spec.rb
+++ b/spec/shale/type/complex_spec/with_using_spec.rb
@@ -3,6 +3,7 @@
 require 'shale'
 require 'shale/adapter/rexml'
 require 'shale/adapter/csv'
+require 'shale/adapter/rack_url_encoded'
 require 'tomlib'
 
 module ComplexSpec__Using # rubocop:disable Naming/ClassAndModuleCamelCase
@@ -13,6 +14,10 @@ module ComplexSpec__Using # rubocop:disable Naming/ClassAndModuleCamelCase
       attribute :three, Shale::Type::String
 
       hsh do
+        map 'one', using: { from: :one_from, to: :one_to }
+      end
+
+      urlencoded do
         map 'one', using: { from: :one_from, to: :one_to }
       end
 
@@ -78,6 +83,11 @@ module ComplexSpec__Using # rubocop:disable Naming/ClassAndModuleCamelCase
       attribute :child, Child
 
       hsh do
+        map 'one', using: { from: :one_from, to: :one_to }
+        map 'child', to: :child
+      end
+
+      urlencoded do
         map 'one', using: { from: :one_from, to: :one_to }
         map 'child', to: :child
       end
@@ -156,6 +166,10 @@ module ComplexSpec__Using # rubocop:disable Naming/ClassAndModuleCamelCase
         map 'one', using: { from: :one_from, to: :one_to }
       end
 
+      urlencoded do
+        map 'one', using: { from: :one_from, to: :one_to }
+      end
+
       json do
         map 'one', using: { from: :one_from, to: :one_to }
       end
@@ -218,6 +232,11 @@ module ComplexSpec__Using # rubocop:disable Naming/ClassAndModuleCamelCase
       attribute :child, Child
 
       hsh do
+        map 'one', using: { from: :one_from, to: :one_to }
+        map 'child', to: :child
+      end
+
+      urlencoded do
         map 'one', using: { from: :one_from, to: :one_to }
         map 'child', to: :child
       end
@@ -294,6 +313,7 @@ RSpec.describe Shale::Type::Complex do
     Shale.toml_adapter = Tomlib
     Shale.csv_adapter = Shale::Adapter::CSV
     Shale.xml_adapter = Shale::Adapter::REXML
+    Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded
   end
 
   context 'with using option' do
@@ -346,6 +366,50 @@ RSpec.describe Shale::Type::Complex do
 
             result = mapper.to_hash([instance, instance])
             expect(result).to eq(hash_collection)
+          end
+        end
+      end
+
+      context 'with urlencoded mapping' do
+        let(:urlencoded) do
+          'one=one&child%5Bone%5D=one'
+        end
+
+        let(:urlencoded_collection) do
+          '%5B%5D%5Bone%5D=one&%5B%5D%5Bchild%5D%5Bone%5D=one&%5B%5D%5Bone%5D=one&%5B%5D%5Bchild%5D%5Bone%5D=one'
+        end
+
+        describe '.from_urlencoded' do
+          it 'maps urlencoded to object' do
+            instance = mapper.from_urlencoded(urlencoded)
+
+            expect(instance.one).to eq('one')
+            expect(instance.child.one).to eq('one')
+          end
+
+          it 'maps collection to object' do
+            instance = mapper.from_urlencoded(urlencoded_collection)
+
+            2.times do |i|
+              expect(instance[i].one).to eq('one')
+              expect(instance[i].child.one).to eq('one')
+            end
+          end
+        end
+
+        describe '.to_urlencoded' do
+          it 'converts objects to urlencoded' do
+            instance = mapper.new(one: 'one', child: child_class.new(one: 'one'))
+
+            result = instance.to_urlencoded
+            expect(result).to eq(urlencoded)
+          end
+
+          it 'converts array to urlencoded' do
+            instance = mapper.new(one: 'one', child: child_class.new(one: 'one'))
+
+            result = mapper.to_urlencoded([instance, instance])
+            expect(result).to eq(urlencoded_collection)
           end
         end
       end
@@ -654,6 +718,59 @@ RSpec.describe Shale::Type::Complex do
 
             result = mapper.to_hash([instance, instance], context: 'foo')
             expect(result).to eq(hash_collection)
+          end
+        end
+      end
+
+      context 'with urlencoded mapping' do
+        describe '.from_urlencoded' do
+          let(:urlencoded) do
+            'one=one&child%5Bone%5D=one'
+          end
+
+          let(:urlencoded_collection) do
+            '%5B%5D%5Bone%5D=one&%5B%5D%5Bchild%5D%5Bone%5D=one&%5B%5D%5Bone%5D=one&%5B%5D%5Bchild%5D%5Bone%5D=one'
+          end
+
+          it 'maps urlencoded to object' do
+            instance = mapper.from_urlencoded(urlencoded, context: 'foo')
+
+            expect(instance.one).to eq('one:foo')
+            expect(instance.child.one).to eq('one:foo')
+          end
+
+          it 'maps collection to object' do
+            instance = mapper.from_urlencoded(urlencoded_collection, context: 'foo')
+
+            2.times do |i|
+              expect(instance[i].one).to eq('one:foo')
+              expect(instance[i].child.one).to eq('one:foo')
+            end
+          end
+        end
+
+        describe '.to_urlencoded' do
+          let(:urlencoded) do
+            'one=one%3Afoo&child%5Bone%5D=one%3Afoo'
+          end
+
+          let(:urlencoded_collection) do
+            '%5B%5D%5Bone%5D=one%3Afoo&%5B%5D%5Bchild%5D%5Bone%5D=one%3Afoo&%5B%5D%5Bone%5D=one%3Afoo&' \
+              '%5B%5D%5Bchild%5D%5Bone%5D=one%3Afoo'
+          end
+
+          it 'converts objects to urlencoded' do
+            instance = mapper.new(one: 'one', child: child_class.new(one: 'one'))
+
+            result = instance.to_urlencoded(context: 'foo')
+            expect(result).to eq(urlencoded)
+          end
+
+          it 'converts array to urlencoded' do
+            instance = mapper.new(one: 'one', child: child_class.new(one: 'one'))
+
+            result = mapper.to_urlencoded([instance, instance], context: 'foo')
+            expect(result).to eq(urlencoded_collection)
           end
         end
       end

--- a/spec/shale/type/date_spec.rb
+++ b/spec/shale/type/date_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'shale/adapter/rexml'
+require 'shale/type'
 require 'shale/type/date'
 
 RSpec.describe Shale::Type::Date do
@@ -33,6 +34,28 @@ RSpec.describe Shale::Type::Date do
     context 'when any other value' do
       it 'returns value' do
         expect(described_class.cast(123)).to eq(123)
+      end
+    end
+  end
+
+  describe '.as_urlencoded' do
+    context 'when value is nil' do
+      it 'returns nil' do
+        expect(described_class.as_urlencoded(nil)).to eq(nil)
+      end
+    end
+
+    context 'when value is present' do
+      it 'returns ISO formatted date' do
+        date = Date.new(2021, 1, 1)
+        expect(described_class.as_urlencoded(date)).to eq('2021-01-01')
+      end
+    end
+
+    context 'with extra params' do
+      it 'returns ISO formatted date' do
+        date = Date.new(2021, 1, 1)
+        expect(described_class.as_urlencoded(date, context: nil)).to eq('2021-01-01')
       end
     end
   end

--- a/spec/shale/type/time_spec.rb
+++ b/spec/shale/type/time_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'shale/adapter/rexml'
+require 'shale/type'
 require 'shale/type/time'
 
 RSpec.describe Shale::Type::Time do
@@ -35,6 +36,28 @@ RSpec.describe Shale::Type::Time do
     context 'when any other value' do
       it 'returns value' do
         expect(described_class.cast(123)).to eq(123)
+      end
+    end
+  end
+
+  describe '.as_urlencoded' do
+    context 'when value is nil' do
+      it 'returns nil' do
+        expect(described_class.as_urlencoded(nil)).to eq(nil)
+      end
+    end
+
+    context 'when value is present' do
+      it 'returns ISO formatted time' do
+        time = Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
+        expect(described_class.as_urlencoded(time)).to eq('2021-01-01T10:10:10+01:00')
+      end
+    end
+
+    context 'with extra params' do
+      it 'returns ISO formatted time' do
+        time = Time.new(2021, 1, 1, 10, 10, 10, '+01:00')
+        expect(described_class.as_urlencoded(time, context: nil)).to eq('2021-01-01T10:10:10+01:00')
       end
     end
   end

--- a/spec/shale/type/value_spec.rb
+++ b/spec/shale/type/value_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe Shale::Type::Value do
     end
   end
 
+  describe '.of_urlencoded' do
+    it 'returns value' do
+      expect(described_class.of_urlencoded(123)).to eq(123)
+    end
+  end
+
+  describe '.as_urlencoded' do
+    it 'returns string value' do
+      expect(described_class.as_urlencoded(123)).to eq('123')
+    end
+  end
+
   describe '.of_json' do
     it 'returns value' do
       expect(described_class.of_json(123)).to eq(123)

--- a/spec/shale_spec.rb
+++ b/spec/shale_spec.rb
@@ -3,6 +3,22 @@
 require 'shale'
 
 RSpec.describe Shale do
+  describe '.urlencoded_adapter' do
+    context 'when adapter is not set' do
+      it 'returns nil' do
+        described_class.urlencoded_adapter = nil
+        expect(described_class.urlencoded_adapter).to eq(nil)
+      end
+    end
+
+    context 'when adapter is set' do
+      it 'returns adapter' do
+        described_class.urlencoded_adapter = :foobar
+        expect(described_class.urlencoded_adapter).to eq(:foobar)
+      end
+    end
+  end
+
   describe '.json_adapter' do
     context 'when adapter is not set' do
       it 'returns default adapter' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'simplecov'
+require 'byebug'
 
 SimpleCov.start do
   add_filter '/spec/'


### PR DESCRIPTION
Hi, I'm a big fan of your library. For me it's a goto solution for request serialization.
Unfortunately I need to integrate with an API that uses the x-www-form-urlencoded format. Shale currently does not support that.

That's why I went out of my way to implement full support for this format using `rack/utils`, the same helper methods that Rails uses. It even handles nested structures.

Here's an example:

```rb
require 'shale'
require 'shale/adapter/rack_url_encoded'
Shale.urlencoded_adapter = Shale::Adapter::RackURLEncoded

class Address < Shale::Mapper
  attribute :city, :string
  attribute :street, :string
  attribute :zip, :string
end

class Person < Shale::Mapper
  attribute :first_name, :string
  attribute :last_name, :string
  attribute :age, :integer
  attribute :married, :boolean, default: -> { false }
  attribute :hobbies, :string, collection: true
  attribute :address, Address
end

person = Person.new(
  first_name: 'John',
  last_name: 'Doe',
  age: 50,
  hobbies: ['Singing', 'Dancing'],
  address: Address.new(city: 'London', street: 'Oxford Street', zip: 'E1 6AN'),
)

urlencoded = person.to_urlencoded
#=> "first_name=John&last_name=Doe&age=50&married=false&hobbies%5B%5D=Singing&hobbies%5B%5D=Dancing&address%5Bcity%5D=London&address%5Bstreet%5D=Oxford+Street&address%5Bzip%5D=E1+6AN"

Person.from_urlencoded(urlencoded)
# => #<Person:0x00000001212c0430
#  @address=#<Address:0x00000001212ed1b0 @city="London", @street="Oxford Street", @zip="E1 6AN">,
#  @age=50,
#  @first_name="John",
#  @hobbies=["Singing", "Dancing"],
#  @last_name="Doe",
#  @married=false>
```