### PR TITLE
Fix Type::Decimal.cast raising on floats with a long decimal expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Fixed
+- [gaoflow] Fix `Type::Decimal.cast` raising on floats with a long decimal expansion (e.g. `0.1 + 0.2`)
+
 ## [1.2.2] - 2025-03-13
 
 ### Added

--- a/lib/shale/type/decimal.rb
+++ b/lib/shale/type/decimal.rb
@@ -19,7 +19,8 @@ module Shale
 
           case value
           when ::BigDecimal then value
-          when ::Float then BigDecimal(value, value.to_s.length)
+          # BigDecimal(float, n) caps n at 16, so parse the float's shortest round-trip string
+          when ::Float then BigDecimal(value.to_s)
           else BigDecimal(value)
           end
         end

--- a/spec/shale/type/decimal_spec.rb
+++ b/spec/shale/type/decimal_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'shale'
 require 'shale/type/decimal'
 
 RSpec.describe Shale::Type::Decimal do
@@ -14,6 +15,18 @@ RSpec.describe Shale::Type::Decimal do
       it 'returns BigDecimal number' do
         expect(described_class.cast(123.123)).to eq(BigDecimal('123.123'))
         expect(described_class.cast(123.33)).to eq(BigDecimal('123.33'))
+      end
+
+      it 'does not raise on floats with a long decimal expansion' do
+        expect(described_class.cast(0.1 + 0.2)).to eq(BigDecimal('0.30000000000000004'))
+        expect(described_class.cast(1.0 / 3.0)).to eq(BigDecimal('0.3333333333333333'))
+        expect(described_class.cast(-(0.1 + 0.2))).to eq(BigDecimal('-0.30000000000000004'))
+      end
+
+      it 'preserves the float value' do
+        [0.1 + 0.2, 1.0 / 3.0, 14.285714285714286, 2.0, 0.0, 1e300, 5e-324].each do |float|
+          expect(described_class.cast(float).to_f).to eq(float)
+        end
       end
     end
 
@@ -39,10 +52,33 @@ RSpec.describe Shale::Type::Decimal do
       it 'returns BigDecimal value' do
         expect(described_class.cast('123.123')).to eq(BigDecimal('123.123'))
       end
+
+      it 'keeps string precision beyond a float' do
+        expect(described_class.cast('0.123456789012345678'))
+          .to eq(BigDecimal('0.123456789012345678'))
+      end
     end
   end
 
   it 'is a registered type' do
     expect(Shale::Type.lookup(:decimal)).to eq(described_class)
+  end
+
+  context 'through the public JSON API' do
+    let(:mapper) do
+      Class.new(Shale::Mapper) do
+        attribute :value, Shale::Type::Decimal
+      end
+    end
+
+    it 'parses a high-precision number without raising' do
+      obj = mapper.from_json('{"value": 0.30000000000000004}')
+      expect(obj.value).to eq(BigDecimal('0.30000000000000004'))
+    end
+
+    it 'round-trips a decimal computed from a float' do
+      json = mapper.new(value: 0.1 + 0.2).to_json
+      expect(mapper.from_json(json).value).to eq(BigDecimal('0.30000000000000004'))
+    end
   end
 end


### PR DESCRIPTION
`Type::Decimal.cast` raises `ArgumentError: precision too large` on any float whose shortest round-trip string is 17+ chars — i.e. most results of float arithmetic:

```ruby
Shale::Type::Decimal.cast(0.1 + 0.2)              # ArgumentError: precision too large
Model.from_json('{"d": 0.30000000000000004}')     # same, via the public JSON path
Model.new(d: 0.1 + 0.2).to_json                    # same, on serialize
```

`cast` passed `value.to_s.length` to `BigDecimal(float, n)`, which accepts at most 16 significant digits; `0.30000000000000004` needs 19, so it overflows. Short floats like `123.123` stay under the limit, which is why the existing spec never hit it.

Parsing the float's shortest round-trip string instead has no precision cap and is exact for the float, so short floats cast identically. Only `Decimal` uses the precision argument, so the fix is localized here.

Tested long/computed floats, value preservation, the `from_json`/`to_json` round-trip, and that short-float/String/Integer/Infinity/NaN behaviour is unchanged.
